### PR TITLE
Footer update

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,7 +15,7 @@ disqus_shortname: prestashopbuild
 
 twitter_username: PrestaShop
 github_username:  PrestaShop
-instagram_username: prestacrew
+instagram_username: prestashop
 spotify_username: prestacrew
 
 # Build settings

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -28,20 +28,20 @@
           <a href="https://www.facebook.com/prestashop/" title="Facebook page">
             <i class="icon-facebook-alt"></i>
           </a>
-        
+
           <a href="https://www.youtube.com/user/prestashop" title="YouTube account">
             <i class="icon-youtube-alt"></i>
           </a>
 
           {% if site.github_username %}
             <a href="https://github.com/{{ site.github_username }}" title="GitHub repository">
-              <i class="icon-github"></i>
+              <i class="icon-github-alt"></i>
             </a>
           {% endif %}
 
           {% if site.twitter_username %}
             <a href="https://twitter.com/{{ site.twitter_username }}" title="Twitter account">
-              <i class="icon-twitter"></i>
+              <i class="icon-twitter-alt"></i>
             </a>
           {% endif %}
 
@@ -50,7 +50,7 @@
               <i class="icon-camera"></i>
             </a>
           {% endif %}
-        
+
           <a href="{{ "/feed.xml" | prepend: site.baseurl }}" title="RSS feed for this blog">
             <i class="icon-rss"></i>
           </a>


### PR DESCRIPTION
- Updated twitter and github logos 
Used more recent ones from the ps icon set

- Replaced the instagram username (pretacrew-> prestashop). 
I would rather have the prestacrew insta on Build but last post was in 2017...




_before_
<img width="659" alt="Capture d’écran 2019-11-30 à 19 12 46" src="https://user-images.githubusercontent.com/25405887/69904634-060ae700-13a9-11ea-80fd-0abe03b55580.png">


_after_
<img width="657" alt="Capture d’écran 2019-11-30 à 19 13 03" src="https://user-images.githubusercontent.com/25405887/69904629-f8edf800-13a8-11ea-8851-a2d344106d68.png">




FYI -  No recent instagram icon in the set