### PR TITLE
Put a fake publication date for core weekly 52 to force display

### DIFF
--- a/news/_posts/core-weekly/2020-01-13-coreweekly-week-52-2019.md
+++ b/news/_posts/core-weekly/2020-01-13-coreweekly-week-52-2019.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "PrestaShop Core Weekly - Week 52 of 2019"
 subtitle: "An inside look at the PrestaShop codebase"
-date:   2020-01-13
+date:   2020-01-12
 authors: [ PrestaShop ]
 image: /assets/images/2017/04/core_weekly_banner.jpg
 icon: icon-calendar


### PR DESCRIPTION
"PrestaShop Core Weekly - Week 52 Of 2019" appears after Core weeklies 01 and 02 of 2020 because of A-Z sorting.

I add a fake publication date to make sure the sort is fixed.