### PR TITLE
Delete the Jekyll default canonical tag 

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,7 +4,6 @@
     {% seo %}
 
     <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}?{{site.time | date: '%s%N'}}">
-    <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
 
     <link rel="shortcut icon" type="image/png" href="/favicon.png" />
 


### PR DESCRIPTION
Fix #569

Deleted the line generating the Jekyll canonical, there is now only one, generated by the jekyll-seo-tag plugin.

Ran locally:
![image](https://user-images.githubusercontent.com/25405887/74543218-422ffb80-4f45-11ea-9aa5-5444a0f612ca.png)
