### PR TITLE
Remove 'release' tag from minor version release lifecycle article

### DIFF
--- a/news/_posts/2020-03-12-ps17-minor-release-lifecycle.md
+++ b/news/_posts/2020-03-12-ps17-minor-release-lifecycle.md
@@ -6,7 +6,6 @@ date:   2020-03-24 14:00:00
 authors: [ MathieuFerment ]
 icon: icon-code
 tags:
- - releases
  - 1.7
  - beta
 ---


### PR DESCRIPTION
Hello @matks 

The article on a minor version release lifecycle appears in the list of Release notes on Build because it have the 'release' tag accessible from the header tab "latest releases".
![Capture d’écran 2020-04-16 à 16 38 37](https://user-images.githubusercontent.com/25405887/79470503-c5cb9e80-8001-11ea-8107-7266790e7156.png)


I removed the tag.

We can add another one if you feel like it. Not a lot of options despite the large number of [tags](https://github.com/PrestaShop/prestashop.github.io/blob/master/_data/tags.yml). 
I thought about 'product', 'process', 'development' and/or 'team'.
