### PR TITLE
Removed 'releases' tag from article on patch release

### DIFF
--- a/news/_posts/2020-03-20-ps17-patch-release-lifecycle.md
+++ b/news/_posts/2020-03-20-ps17-patch-release-lifecycle.md
@@ -6,7 +6,6 @@ date:   2020-04-28 10:00:00
 authors: [ MathieuFerment ]
 icon: icon-code
 tags:
- - releases
  - 1.7
  - beta
 ---


### PR DESCRIPTION
Same pb as last time, I removed the tag so it doesn't appear in the list of Release note.

I suggest creating a new tag 'release-note' to use for release notes, so we don't have the pb https://github.com/PrestaShop/prestashop.github.io/issues/687
Wdyt?
