### PR TITLE
Add missing meta images in Matks's release cycles articles

### DIFF
--- a/news/_posts/2020-03-12-ps17-minor-release-lifecycle.md
+++ b/news/_posts/2020-03-12-ps17-minor-release-lifecycle.md
@@ -4,6 +4,7 @@ title: "PrestaShop 1.7 minor release lifecycle"
 subtitle: "The journey of a minor release of PS 1.7, step by step"
 date:   2020-03-24 14:00:00
 authors: [ MathieuFerment ]
+image: /assets/images/theme/meta-logo-build.png
 icon: icon-code
 tags:
  - 1.7

--- a/news/_posts/2020-03-20-ps17-patch-release-lifecycle.md
+++ b/news/_posts/2020-03-20-ps17-patch-release-lifecycle.md
@@ -4,6 +4,7 @@ title: "PrestaShop 1.7 patch release lifecycle"
 subtitle: "The journey of a patch release of PS 1.7, step by step"
 date:   2020-04-28 10:00:00
 authors: [ MathieuFerment ]
+image: /assets/images/theme/meta-logo-build.png
 icon: icon-code
 tags:
  - 1.7


### PR DESCRIPTION
Fix #707 

Add Build's default meta image to the following articles:
- PrestaShop 1.7 minor release lifecycle
- PrestaShop 1.7 patch release lifecycle