### PR TITLE
Fix order of coreweekly 20 and 21

### DIFF
--- a/news/_posts/core-weekly/2020-05-25-coreweekly-20-2020.md
+++ b/news/_posts/core-weekly/2020-05-25-coreweekly-20-2020.md
@@ -21,7 +21,7 @@ This edition of the Core Weekly report highlights changes in PrestaShop's core c
 - [49 issues have been closed](https://github.com/search?q=org%3APrestaShop+is%3Apublic++-repo%3Aprestashop%2Fprestashop.github.io++is%3Aissue+closed%3A2020-05-11..2020-05-17), including [12 fixed issues](https://github.com/search?q=org%3APrestaShop+is%3Apublic++-repo%3Aprestashop%2Fprestashop.github.io++is%3Aissue+label%3Afixed+closed%3A2020-05-11..2020-05-17) on the core;
 - [58 pull requests have been opened](https://github.com/search?q=org%3APrestaShop+is%3Apublic++-repo%3Aprestashop%2Fprestashop.github.io++is%3Apr+created%3A2020-05-11..2020-05-17) in the project repositories;
 - [61 pull requests have been closed](https://github.com/search?q=org%3APrestaShop+is%3Apublic++-repo%3Aprestashop%2Fprestashop.github.io++is%3Apr+closed%3A2020-05-11..2020-05-17), including [47 merged pull requests](https://github.com/search?q=org%3APrestaShop+is%3Apublic++-repo%3Aprestashop%2Fprestashop.github.io++is%3Apr+merged%3A2020-05-11..2020-05-17).
-        
+
 
 
 ## Code changes in the 'develop' branch

--- a/news/_posts/core-weekly/2020-05-25-coreweekly-20-2020.md
+++ b/news/_posts/core-weekly/2020-05-25-coreweekly-20-2020.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "PrestaShop Core Weekly - Week 20 of 2020"
 subtitle: "An inside look at the PrestaShop codebase"
-date:   2020-05-25
+date:   2020-05-25 10:00:00
 authors: [ PrestaShop ]
 image: /assets/images/2017/04/core_weekly_banner.jpg
 icon: icon-calendar

--- a/news/_posts/core-weekly/2020-05-25-coreweekly-21-2020.md
+++ b/news/_posts/core-weekly/2020-05-25-coreweekly-21-2020.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "PrestaShop Core Weekly - Week 21 of 2020"
 subtitle: "An inside look at the PrestaShop codebase"
-date:   2020-05-25
+date:   2020-05-25 14:00:00
 authors: [ PrestaShop ]
 image: /assets/images/2017/04/core_weekly_banner.jpg
 icon: icon-calendar


### PR DESCRIPTION
Fix #712 

Month and day were inverted in the article name

Couldn't test locally, have trouble with bundle (algolia vs Nokogiri) 