### PR TITLE
Improve sidebar

### DIFF
--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -1,6 +1,6 @@
 xavierborderie:
     display_name: Xavier Borderie
-    role: Open Source Advocate @ PrestaShop
+    role: Open Source Advocate
     avatar: https://avatars2.githubusercontent.com/u/2833749
     email: xavier@prestashop.com
     github: xBorderie
@@ -9,7 +9,7 @@ xavierborderie:
 
 julienbourdeau:
     display_name: Julien Bourdeau
-    role: Core Developer @ PrestaShop
+    role: Core Developer
     avatar: https://avatars1.githubusercontent.com/u/1525636
     email: julien@prestashop.com
     twitter: julienbourdeau
@@ -21,7 +21,7 @@ julienbourdeau:
 
 alexeven:
     display_name: Alex Even
-    role: Product Manager @ PrestaShop
+    role: Product Manager
     avatar: https://avatars0.githubusercontent.com/u/7910738
     email: alexandra.even@prestashop.com
     github: AlexEven
@@ -42,11 +42,11 @@ djfm:
     email: fmdj@prestashop.com
     avatar: https://avatars0.githubusercontent.com/u/1460499
     github: djfm
-    role: Product Manager @ PrestaShop
+    role: Product Manager
 
 jeromenadaud:
     display_name: Jérôme Nadaud
-    role: R&D Director @ PrestaShop
+    role: R&D Director
     avatar: https://avatars1.githubusercontent.com/u/4747745
     email: jerome@prestashop.com
     twitter: JeromeNadaud
@@ -65,7 +65,7 @@ jocelynfournier:
 
 tchauviere:
     display_name: Thibaud Chauvière
-    role: Core Developer @ PrestaShop
+    role: Core Developer
     avatar: https://avatars3.githubusercontent.com/u/5026142
     twitter: ChoviChova
     github: tchauviere
@@ -73,7 +73,7 @@ tchauviere:
 
 agriveau:
     display_name: Adrien Griveau
-    role: Visual Designer @ PrestaShop
+    role: Visual Designer
     avatar: https://avatars0.githubusercontent.com/u/10723029
     email: adrien.griveau@prestashop.com
     twitter: Griveau
@@ -84,7 +84,7 @@ agriveau:
 
 sLevaillant:
     display_name: Sébastien Levaillant
-    role: Director of Product Management @ PrestaShop
+    role: Director of Product Management
     avatar: http://1.gravatar.com/avatar/76391760617c1f91a4977e9691e248a3
     email: sebastien.levaillant@prestashop.com
     twitter: s_levaillant
@@ -106,7 +106,7 @@ alexsegura:
 
 margauxchoplin:
     display_name: Margaux Choplin
-    role: International Project Manager @ PrestaShop
+    role: International Project Manager
     avatar: https://pbs.twimg.com/profile_images/899990025294811136/adR4dEkF_400x400.jpg
     email: margaux.choplin@prestashop.com
     twitter: margchop
@@ -118,7 +118,7 @@ margauxchoplin:
 
 maximebiloe:
     display_name: Maxime Biloé
-    role: Core Developer @ PrestaShop
+    role: Core Developer
     avatar: https://avatars3.githubusercontent.com/u/2203436
     email: maxime.biloe@prestashop.com
     twitter: maximebiloe
@@ -128,7 +128,7 @@ maximebiloe:
 
 julienmartin:
     display_name: Julien Martin
-    role: Core Developer @ PrestaShop
+    role: Core Developer
     avatar: https://fr.gravatar.com/userimage/81162371/facaed47afd586951ba446bf68d59273.jpg?size=256
     email: julien.martin@prestashop.com
     twitter: shudrum
@@ -136,7 +136,7 @@ julienmartin:
 
 quentinau:
     display_name: Quentin Audrain
-    role: Product Marketing Manager @ PrestaShop
+    role: Product Marketing Manager
     avatar: https://secure.gravatar.com/avatar/ccec54da0abb205cc5bd253778433103
     email: quentin@prestashop.com
     twitter: quentinau
@@ -144,13 +144,13 @@ quentinau:
 
 guillaumebruere:
     display_name: Guillaume Bruere
-    role: Product Manager @ PrestaShop
+    role: Product Manager
     avatar: https://fr.gravatar.com/userimage/91609995/38361fbb8f44093203780a23155f280d.jpg
     email: guillaume.bruere@prestashop.com
 
 vincentbz:
     display_name: Vincent Beudez
-    role: Product Owner @ PrestaShop
+    role: Product Owner
     avatar: https://fr.gravatar.com/userimage/65559921/1e5500050af014f2cb41132d7998be1f.jpeg
     email: vincent.beudez@prestashop.com
     twitter: vincent_bz
@@ -167,7 +167,7 @@ jesusruizgarcia:
 
 mandrieu:
     display_name: Mickaël Andrieu
-    role: Technical evangelist @ PrestaShop / Creator of PrestonBot
+    role: Technical evangelist / Creator of PrestonBot
     avatar: https://avatars3.githubusercontent.com/u/1247388
     email: mickael.andrieu@prestashop.com
     twitter: mickael_andrieu
@@ -175,7 +175,7 @@ mandrieu:
 
 leamendes:
     display_name: Léa Mendes Da Silva
-    role: Product Designer @ PrestaShop
+    role: Product Designer
     avatar: https://avatars1.githubusercontent.com/u/16487836?v=3&s=460
     email: lea@prestashop.com
     twitter: LeaMendesign
@@ -183,7 +183,7 @@ leamendes:
 
 llandry:
     display_name: Laurène Landry
-    role: Content Specialist @ PrestaShop
+    role: Content Specialist
     avatar: https://avatars1.githubusercontent.com/u/19404893?v=3&s=400
     email: laurene.landry@prestashop.com
 
@@ -208,7 +208,7 @@ kpodemski:
 
 aleeks:
     display_name: Alex Sampaio
-    role: Core Developer @ PrestaShop
+    role: Core Developer
     avatar: https://avatars3.githubusercontent.com/u/9074610?v=3&s=460
     email: alex.sampaio@prestashop.com
     twitter: alexsampaio_fr
@@ -217,14 +217,14 @@ aleeks:
 
 thierrymarianne:
     display_name: Thierry Marianne
-    role: Core Developer @ PrestaShop
+    role: Core Developer
     avatar: https://avatars1.githubusercontent.com/u/1053622?v=3&s=460
     email: thierry.marianne@prestashop.com
     github: thierrymarianne
 
 tristanlehot:
     display_name: Tristan Lehot
-    role: Product Designer @ PrestaShop
+    role: Product Designer
     avatar: https://pbs.twimg.com/profile_images/786325858323685376/_dP-9-Su.jpg
     email: tristan.lehot@prestashop.com
     twitter: TristanDardel
@@ -233,7 +233,7 @@ tristanlehot:
 
 thomasn:
     display_name: Thomas Nabord
-    role: Core Developer @ PrestaShop
+    role: Core Developer
     avatar: https://avatars0.githubusercontent.com/u/6768917?v=3&s=460
     email: thomas.nabord+build@prestashop.com
     twitter: Quetzacoalt91
@@ -241,12 +241,12 @@ thomasn:
 
 emmanuelfages:
     display_name: Emmanuel Fages
-    role: Product Manager @ PrestaShop
+    role: Product Manager
     avatar: https://i.imgur.com/p9sjjxr.jpg
 
 LouiseBonnard:
     display_name: Louise Bonnard
-    role: Product Manager @ PrestaShop
+    role: Product Manager
     avatar: https://avatars2.githubusercontent.com/u/32565890
     email: louise.bonnard@prestashop.com
     github: LouiseBonnard
@@ -254,34 +254,34 @@ LouiseBonnard:
 
 ThomasLeviandier:
     display_name: Thomas Leviandier
-    role: Core Developer @ PrestaShop
+    role: Core Developer
     avatar: https://avatars2.githubusercontent.com/u/7364936
     email: thomas.leviandier@prestashop.com
     github: tomlev
 
 AurelienPelletier:
     display_name: Aurélien Pelletier
-    role: Chief Technology Officer @ PrestaShop
+    role: Chief Technology Officer
     avatar: https://avatars1.githubusercontent.com/u/720961?s=460&v=4
     email: aurelien.pelletier@prestashop.com
     github: toutantic
 
 MehdiBadrani:
     display_name: Mehdi Badrani
-    role: QA Manager @ PrestaShop
+    role: QA Manager
     avatar: https://avatars3.githubusercontent.com/u/29543279?s=400&v=4
     email: mehdi.badrani@prestashop.com
     github: mbadrani
 
 ThomasJouve:
     display_name: Thomas Jouve
-    role: Integration Fund Assistant @ PrestaShop
+    role: Integration Fund Assistant
     avatar: https://i.vimeocdn.com/portrait/9813163_300x300
     email: thomas.jouve@prestashop.com
 
 PabloBorowicz:
     display_name: Pablo Borowicz
-    role: Lead Core Developer @ PrestaShop
+    role: Lead Core Developer
     avatar: https://avatars3.githubusercontent.com/u/1009343?s=460&v=4
     email: pablo.borowicz@prestashop.com
     github: eternoendless
@@ -292,61 +292,61 @@ PrestaShop:
 
 MarilouNielsen:
     display_name: Marilou Nielsen
-    role: International Project Manager @ PrestaShop
+    role: International Project Manager
     avatar: https://lh3.googleusercontent.com/-hx1Rsf60g8k/WrIkqE0mckI/AAAAAAAAADo/c1GixJA3O0w-hmCX-Ueib3wkk5INFXg-ACL0BGAYYCw/h814/2018-03-21.png
     email: marie-louise.nielsen@prestashop.com
 
 AntoineThomas:
     display_name: Antoine Thomas
-    role: Open Source Evangelist @ PrestaShop
+    role: Open Source Evangelist
     avatar: https://avatars2.githubusercontent.com/u/4619685?s=460&v=4
     email: antoine.thomas@prestashop.com
     github: ttoine
 
 ColineGinestet:
     display_name: Coline Ginestet
-    role: Product Manager @ PrestaShop
+    role: Product Manager
     avatar: https://avatars3.githubusercontent.com/u/35263827?s=400&v=4
     email: coline.ginestet@prestashop.com
     github: colinegin
 
 ChloeAllard:
     display_name: Chloé Allard
-    role: Talent Acquisition Specialist @ PrestaShop
+    role: Talent Acquisition Specialist
     avatar: https://media.licdn.com/dms/image/C4E03AQHyePvmXo_4gA/profile-displayphoto-shrink_800_800/0?e=1529917200&v=beta&t=kJpJvb-lZbBScyvax-AEXUs0J9i-3ccJVpT5LQaiTBg
     email: chloe.allard@prestashop.com
 
 BilalDriche:
     display_name: Bilal Driche
-    role: Product Owner / Analyst @ PrestaShop
+    role: Product Owner / Analyst
     avatar: https://avatars1.githubusercontent.com/u/40759259?s=400&u=8e83e7f83f37ff75302ebf8d45955478e1ab4331&v=4
     email: bilal.driche@prestashop.com
     github: BilalDr
 
 PierreRambaud:
     display_name: Pierre Rambaud
-    role: Senior Core Developer @ PrestaShop
+    role: Senior Core Developer
     avatar: https://avatars2.githubusercontent.com/u/1462701?s=400&v=4
     email: pierre.rambaud@prestashop.com
     github: PierreRambaud
 
 MarionFrancois:
     display_name: Marion François
-    role: Product Owner @ PrestaShop
+    role: Product Owner
     avatar: https://avatars2.githubusercontent.com/u/13449658?s=460&v=4
     email: marion.francois@prestashop.com
     github: marionf
 
 MathieuFerment:
     display_name: Mathieu Ferment
-    role: Core Developer @ PrestaShop
+    role: Core Developer
     avatar: https://avatars2.githubusercontent.com/u/3830050?s=460&v=4
     email: mathieu.ferment@prestashop.com
     github: matks
 
 SamuelPires:
     display_name: Samuel Pirès
-    role: Product Manager @ PrestaShop
+    role: Product Manager
     avatar: https://avatars2.githubusercontent.com/u/25405887?s=460&v=4
     email: samuel.pires@prestashop.com
     github: sam-pires
@@ -359,20 +359,20 @@ TanguySalmon:
 
 SimonGarny:
     display_name: Simon Garny
-    role: QA Manager @ PrestaShop
+    role: QA Manager
     avatar: https://avatars0.githubusercontent.com/u/49909275?s=460&v=4
     github: SimonGrn
-    
+
 MateusShirlaw:
     display_name: Mateus Shirlaw
-    role: Product Manager @ PrestaShop
+    role: Product Manager
     avatar: https://avatars0.githubusercontent.com/u/43613217?5?s=460&v=4
     email: mateus.shirlaw@prestashop.com
     github: MatShir
 
 JuneByun:
     display_name: June Byun
-    role: Product Content Manager @ PrestaShop
+    role: Product Content Manager
     avatar: https://avatars3.githubusercontent.com/u/64894223
     email: june.byun@prestashop.com
     github: Junebyun

--- a/_includes/author-meta.html
+++ b/_includes/author-meta.html
@@ -5,8 +5,13 @@
 </div>
 
 <div class="aside-meta">Written by</div>
-<p class="author-name">
+<div class="author-name">
   {% for a in page.authors %}
-    {{ site.data.authors[a]["display_name"] }} <br />
+      <div class="author-item">
+          <div class="author-display-name">{{ site.data.authors[a]["display_name"] }}</div>
+      {% unless site.data.authors[a]["role"] == '' %}
+          <div class="author-display-role">{{ site.data.authors[a]["role"] }}</div>
+      {% endunless %}
+      </div>
   {% endfor %}
-</p>
+</div>

--- a/_includes/post-meta-sidebar.html
+++ b/_includes/post-meta-sidebar.html
@@ -1,0 +1,4 @@
+<div class="aside-meta">Published</div>
+<p class="publish-date">
+    {{ page.date | date: "%b %-d, %Y" }}
+</p>

--- a/_includes/post-meta.html
+++ b/_includes/post-meta.html
@@ -4,8 +4,7 @@
 
       <div class="col-md-4">
         <ul class="details">
-
-          <li>{{ page.date | date: "%b %-d, %Y" }}</li>
+          <li class="hidden-md hidden-lg">{{ page.date | date: "%b %-d, %Y" }}</li>
 
           {% unless page.tags == empty %}
             <li>

--- a/_includes/share-buttons.html
+++ b/_includes/share-buttons.html
@@ -1,18 +1,10 @@
 
-<p class="aside-meta">Share this</p>
+<div class="aside-meta">Share this</div>
 
-<ul class="list-group">
+<a href="https://twitter.com/intent/tweet?text={{ page.title | escape }}&amp;url={{ site.url }}{{ page.url }}&amp;via={{ site.twitter_username }}&amp;related={{ site.twitter_username }}" rel="nofollow" target="_blank" title="Share on Twitter">
+    <i class="icon-twitter-alt"></i>
+</a>
 
-  <li>
-    <a class="list-group-item" href="https://twitter.com/intent/tweet?text={{ page.title | escape }}&amp;url={{ site.url }}{{ page.url }}&amp;via={{ site.twitter_username }}&amp;related={{ site.twitter_username }}" rel="nofollow" target="_blank" title="Share on Twitter">
-      <i class="icon-twitter-alt"></i> Twitter
-    </a>
-  </li>
-
-  <li>
-    <a class="list-group-item" href="https://facebook.com/sharer.php?u={{ site.url }}{{ page.url }}" rel="nofollow" target="_blank" title="Share on Facebook">
-      <i class="icon-facebook-alt"></i> Facebook
-    </a>
-  </li>
-
-</ul>
+<a href="https://facebook.com/sharer.php?u={{ site.url }}{{ page.url }}" rel="nofollow" target="_blank" title="Share on Facebook">
+    <i class="icon-facebook-alt"></i>
+</a>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -44,6 +44,10 @@ layout: default
         {% include author-meta.html %}
       </aside>
 
+      <aside class="post-meta-sidebar">
+        {% include post-meta-sidebar.html %}
+      </aside>
+
       <aside class="share-buttons">
         {% include share-buttons.html %}
       </aside>

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -563,17 +563,20 @@ $autocomplete-width: 600px;
  * Content
  */
 #post-sidebar aside {
-    margin-bottom: $spacing-unit;
+    margin-bottom: $spacing-unit/2;
     margin-left: $spacing-unit/2;
     &:not(:first-child) {
-        padding-top: $spacing-unit;
+        padding-top: $spacing-unit/2;
+    }
+
+    .publish-date {
+        font-size: .8em;
     }
 }
 
 .aside-meta {
     font-size: 0.7em;
     color: $grey-color;
-
 }
 
 .alert-note {
@@ -590,10 +593,12 @@ $autocomplete-width: 600px;
  * Author
  */
 .author {
+    margin-right: -$grid-gutter-width*2/3;
     border-right: solid 1px $grey-color-light;
+    padding-right: 5px;
 }
 .author-avatar {
-    margin-bottom: 0.5*$spacing-unit;
+    margin-bottom: $spacing-unit/2;
     img {
         float: left;
         max-width: 40%;
@@ -604,23 +609,36 @@ $autocomplete-width: 600px;
 .author-name {
     font-size: 0.9em;
     text-align: left;
+    .author-item {
+      line-height: 1.2;
+      & + .author-item {
+          margin-top: .8em;
+      }
+    }
+    .author-display-name {
+        font-weight: 600;
+        margin-top: .2em;
+    }
+    .author-display-role {
+        font-size: .9em;
+        margin-top: .2em;
+    }
 }
 
 /**
  * Share buttons
  */
 aside.share-buttons {
-    ul {
-        margin: 0 !important;
-        list-style-type: none;
-        a {
-            color: $text-color;
-            font-size: 1em;
-        }
-        li {
-            margin-bottom: 6px;
-            font-size: 0.8em;
-        }
+    .aside-meta {
+        margin-bottom: 5px;
+    }
+    a {
+        color: $text-color;
+        font-size: 2.2rem;
+        display: inline-block;
+        width: 3rem;
+        height: 3rem;
+        text-align: center;
     }
 }
 


### PR DESCRIPTION
Improved sidebar on all articles:

* Add post date on sidebar, make the one at the bottom only visible on small screens
* Add author's role on the sidebar
* Display only icons for social share buttons
* Other style improvements

Before:
<img width="991" alt="Screenshot 2020-07-13 at 18 00 29" src="https://user-images.githubusercontent.com/1009343/87326241-c2797d80-c532-11ea-9a99-d5e7fb958564.png">

Now:
<img width="1022" alt="Screenshot 2020-07-13 at 17 58 46" src="https://user-images.githubusercontent.com/1009343/87326156-a970cc80-c532-11ea-9322-c756075a6bee.png">

Other examples:

<img width="450" alt="Screenshot 2020-07-13 at 18 02 40" src="https://user-images.githubusercontent.com/1009343/87326495-171cf880-c533-11ea-81f1-f1f0f3d3220b.png">
<img width="450" alt="Screenshot 2020-07-13 at 18 02 32" src="https://user-images.githubusercontent.com/1009343/87326504-197f5280-c533-11ea-83f1-e57b8387794d.png">
<img width="450" alt="Screenshot 2020-07-13 at 18 02 22" src="https://user-images.githubusercontent.com/1009343/87326508-1ab07f80-c533-11ea-9906-05232862f7f7.png">
<img width="450" alt="Screenshot 2020-07-13 at 18 02 12" src="https://user-images.githubusercontent.com/1009343/87326510-1b491600-c533-11ea-8e9f-6d61f02c377f.png">
<img width="450" alt="Screenshot 2020-07-13 at 18 01 59" src="https://user-images.githubusercontent.com/1009343/87326512-1be1ac80-c533-11ea-9ab5-897017d142c0.png">
<img width="450" alt="Screenshot 2020-07-13 at 18 01 50" src="https://user-images.githubusercontent.com/1009343/87326514-1be1ac80-c533-11ea-8bd4-e43b7cf49264.png">
