### PR TITLE
Use absolute URL for twitter meta

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,7 +3,7 @@
 
     {% seo %}
 
-    <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}?{{site.time | date: '%s%N'}}">
+    <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.url }}?{{site.time | date: '%s%N'}}">
 
     <link rel="shortcut icon" type="image/png" href="/favicon.png" />
 
@@ -17,7 +17,7 @@
         <meta name="twitter:site" content="@PrestaShop">
         <meta name="twitter:title" content="{{ page.title }}">
         <meta name="twitter:description" content="{{ page.subtitle }}">
-        <meta name="twitter:image" content="{{ page.twitter_image | prepend: site.baseurl }}">
+        <meta name="twitter:image" content="{{ page.twitter_image | prepend: site.url }}">
     {% endif %}
 
     {% include analytics.html %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | It seems `prepend: site.baseurl }}` does not work, we need to use `site.url` instead to have absolute URLs
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
