### PR TITLE
Fix core weekly 25

### DIFF
--- a/news/_posts/core-weekly/2020-06-22-coreweekly-25-2020.md
+++ b/news/_posts/core-weekly/2020-06-22-coreweekly-25-2020.md
@@ -129,7 +129,8 @@ In the meantime, [feedbacks continue to arrive on GitHub](https://github.com/Pre
 
 ### Changes in developer documentation
 * [#589](https://github.com/PrestaShop/docs/pull/589): Explain _disable_module_prefix option, by [@matks](https://github.com/matks)
-* [#588](https://github.com/PrestaShop/docs/pull/588): Add {{% children %}} in Themes > Reference > Templates, by [@matks](https://github.com/matks)
+* [#588](https://github.com/PrestaShop/docs/pull/588): Add {% raw %}{{% children %}}{% endraw %}
+ in Themes > Reference > Templates, by [@matks](https://github.com/matks)
 * [#585](https://github.com/PrestaShop/docs/pull/585): Update license headers, by [@jolelievre](https://github.com/jolelievre)
 * [#583](https://github.com/PrestaShop/docs/pull/583): Rename "Core Development" to "Core Development Reference", by [@eternoendless](https://github.com/eternoendless)
 * [#582](https://github.com/PrestaShop/docs/pull/582): Move webservice into a section of its own, by [@eternoendless](https://github.com/eternoendless)


### PR DESCRIPTION
There was a `{{ %children% }}` string in Core Weekly 25 so Jekyll tried to render it. I escape it to remove an error.