### PR TITLE
Add h1 on HP + alt to logo

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,8 +7,11 @@
       <div class="search-button"><i class="icon icon-magnifying-glass"></i></div>
 
       <div id="logo" class="">
+        {% if page.type == "home" %}
+          <h1 class="sr-only">Prestashop Developer's Blog</h1>
+        {% endif %}
         <a href="{{ site.url }}{{ site.baseurl }}">
-          <img src="{{ "/assets/images/theme/new-logo.png" | prepend: site.baseurl }}" alt="">
+          <img src="{{ "/assets/images/theme/new-logo.png" | prepend: site.baseurl }}" alt="Prestashop Developer's Blog Logo">
         </a>
       </div>
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Add `alt` to the logo + h1 on homepage
| Type?         |   improvement
| BC breaks?    |  no
| Deprecations? | no
| Fixed ticket? | Fixes #571 
| How to test?  | Inspect the element for the alt and get an headings extension for you browser and check H1 on homepage

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
