### PR TITLE
Fix broken assets when serving the page using Jekyll server and browsing it with Chrome

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -60,3 +60,8 @@ howtos:
   icon: fa-retweet-1
 - translation:
   icon: fa-globe
+
+# Required to use local jekyll server with Chrome
+webrick:
+  headers:
+    Access-Control-Allow-Origin: "*"


### PR DESCRIPTION


<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer blog! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | When you serve the site using Jekyll server on your local environment, Chrome will refuse to load assets unless the headers `Access-Control-Allow-Origin` are sent.
| Fixed ticket? | ~

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
