### PR TITLE
Add missing 17xy tags and fix some in posts

### DIFF
--- a/news/_posts/releases/2017-07-04-prestashop-1-7-2-0-rc-1.md
+++ b/news/_posts/releases/2017-07-04-prestashop-1-7-2-0-rc-1.md
@@ -7,7 +7,7 @@ authors: [ xavierborderie ]
 icon: icon-gift
 tags:
 - 1.7
-- 1.7.2.0
+- 1.7.2.x
 - version
 - releases
 - development

--- a/news/_posts/releases/2017-12-15-prestashop-1-7-3-0-beta-1.md
+++ b/news/_posts/releases/2017-12-15-prestashop-1-7-3-0-beta-1.md
@@ -7,7 +7,7 @@ authors: [ LouiseBonnard ]
 icon: icon-gift
 tags:
 - 1.7
-- 1.7.3.0
+- 1.7.3.x
 - version
 - beta
 - releases

--- a/news/_posts/releases/2018-02-19-prestashop-1-7-3-0-rc-1.md
+++ b/news/_posts/releases/2018-02-19-prestashop-1-7-3-0-rc-1.md
@@ -7,7 +7,7 @@ authors: [ LouiseBonnard ]
 icon: icon-gift
 tags:
 - 1.7
-- 1.7.3.0
+- 1.7.3.x
 - version
 - rc
 - releases

--- a/news/_posts/releases/2020-05-13-prestashop-1-7-7-0-beta-release.md
+++ b/news/_posts/releases/2020-05-13-prestashop-1-7-7-0-beta-release.md
@@ -7,7 +7,7 @@ authors: [ PrestaShop ]
 image: /assets/images/2020/05/1.7.7_beta_banner.jpg
 icon: icon-leaf
 tags:
- - 1.7.7
+ - 1.7.7.x
  - version
  - beta
  - minor

--- a/news/_posts/releases/2020-09-01-prestashop-1-7-7-0-beta2-release.md
+++ b/news/_posts/releases/2020-09-01-prestashop-1-7-7-0-beta2-release.md
@@ -7,7 +7,7 @@ authors: [ PrestaShop ]
 image: /assets/images/2020/09/build_beta_2.png
 icon: icon-leaf
 tags:
- - 1.7.7
+ - 1.7.7.x
  - version
  - beta
  - minor

--- a/news/_posts/releases/2020-11-03-prestashop-1-7-7-0-rc-release.md
+++ b/news/_posts/releases/2020-11-03-prestashop-1-7-7-0-rc-release.md
@@ -7,7 +7,7 @@ authors: [ PrestaShop ]
 image: /assets/images/2020/11/build-177RC1.png
 icon: icon-leaf
 tags:
- - 1.7.7
+ - 1.7.7.x
  - version
  - rc
  - minor

--- a/tag/1.7.0.x.md
+++ b/tag/1.7.0.x.md
@@ -1,0 +1,6 @@
+---
+layout: articles_by_tag
+type: tag
+tag: 1.7.0.x
+permalink: /tag/1.7.0.x/
+---

--- a/tag/1.7.1.x.md
+++ b/tag/1.7.1.x.md
@@ -1,0 +1,6 @@
+---
+layout: articles_by_tag
+type: tag
+tag: 1.7.1.x
+permalink: /tag/1.7.1.x/
+---

--- a/tag/1.7.2.x.md
+++ b/tag/1.7.2.x.md
@@ -1,0 +1,6 @@
+---
+layout: articles_by_tag
+type: tag
+tag: 1.7.2.x
+permalink: /tag/1.7.2.x/
+---

--- a/tag/1.7.3.x.md
+++ b/tag/1.7.3.x.md
@@ -1,0 +1,6 @@
+---
+layout: articles_by_tag
+type: tag
+tag: 1.7.3.x
+permalink: /tag/1.7.3.x/
+---

--- a/tag/1.7.4.x.md
+++ b/tag/1.7.4.x.md
@@ -1,0 +1,6 @@
+---
+layout: articles_by_tag
+type: tag
+tag: 1.7.4.x
+permalink: /tag/1.7.4.x/
+---

--- a/tag/1.7.5.x.md
+++ b/tag/1.7.5.x.md
@@ -1,0 +1,6 @@
+---
+layout: articles_by_tag
+type: tag
+tag: 1.7.5.x
+permalink: /tag/1.7.5.x/
+---

--- a/tag/1.7.6.x.md
+++ b/tag/1.7.6.x.md
@@ -1,0 +1,6 @@
+---
+layout: articles_by_tag
+type: tag
+tag: 1.7.6.x
+permalink: /tag/1.7.6.x/
+---

--- a/tag/1.7.7.x.md
+++ b/tag/1.7.7.x.md
@@ -1,0 +1,6 @@
+---
+layout: articles_by_tag
+type: tag
+tag: 1.7.7.x
+permalink: /tag/1.7.7.x/
+---


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer blog! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Add missing 17xy tags (and fix some in posts). They are used in all release posts but lead to 404 pages although being featured in pages like https://build.prestashop.com/news/prestashop-1-7-6-9-maintenance-release/
| Fixed ticket? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
