### PR TITLE
Remove duplicate title from performance article 1

### DIFF
--- a/news/_posts/performance/2020-12-07-performance-and-prestashop.md
+++ b/news/_posts/performance/2020-12-07-performance-and-prestashop.md
@@ -11,7 +11,6 @@ tags: [performance, whitepaper]
 Introducing a new series of article to talk about performance, benchmarking and PrestaShop!
 
 
-# Performance (& PrestaShop)
 
 You may have heard of it, but we'll soon release a White Paper, which is all about PrestaShop's performance, how to benchmark it and how it behaves under loads. And what to do to keep it responding under 300ms.
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer blog! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Remove duplicate title from https://build.prestashop.com/news/performance-and-prestashop/
| Fixed ticket? | 

@djodjo3 Sorry for not seeing it during review, title is duplicated in https://build.prestashop.com/news/performance-and-prestashop/ . I remove the 2nd one to avoid content duplication and to avoid double `<h1>` (not good for SEO)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
