### PR TITLE
Add default image for posts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -65,3 +65,10 @@ howtos:
 webrick:
   headers:
     Access-Control-Allow-Origin: "*"
+
+defaults:
+  -
+    scope:
+      path: "news"
+    values:
+      image: "/assets/images/theme/meta-logo-build.png"


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer blog! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | I use jekyll [Front Matters Default](https://jekyllrb.com/docs/configuration/front-matter-defaults/) to add a default `image` property to all posts. This `image` property is used by jekyll-feed to generate a `og:image` meta tag.<br/><br/>Posts that have a custom `image` property are not modified.
| Fixed ticket? | Fixes https://github.com/PrestaShop/prestashop.github.io/issues/817

This PR will allow that posts without an `image` property, that look like this today (https://twitter.com/PrestaShop/status/1334071559842131968)
<img width="595" alt="Capture d’écran 2020-12-14 à 22 20 46" src="https://user-images.githubusercontent.com/3830050/102137896-d74c9b00-3e5b-11eb-9e27-326027925a38.png">

will become like this (https://twitter.com/PrestaShop/status/1333777719042031616)
<img width="601" alt="Capture d’écran 2020-12-14 à 22 24 29" src="https://user-images.githubusercontent.com/3830050/102137920-e03d6c80-3e5b-11eb-8967-dcf607d2a409.png">


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
