### PR TITLE
Fix Core Weekly 16 to 20 of 2021 with missing 178x data

### DIFF
--- a/news/_posts/core-weekly/2021-04-26-coreweekly-16-2021.md
+++ b/news/_posts/core-weekly/2021-04-26-coreweekly-16-2021.md
@@ -77,6 +77,17 @@ During this session we will present some of the new 1.7.8 achievements.
 * [#23975](https://github.com/PrestaShop/PrestaShop/pull/23975): Fix ThemeExporterTest test path. Thank you [@mvorisek](https://github.com/mvorisek)
 
 
+## Code changes in the '1.7.8.x' branch
+
+
+### Front office
+* [#24151](https://github.com/PrestaShop/PrestaShop/pull/24151): Replace price drop flag by on sale, by [@marionf](https://github.com/marionf)
+
+
+### Tests
+* [#24148](https://github.com/PrestaShop/PrestaShop/pull/24148): Use base:7.4-apache image for UI tests, by [@boubkerbribri](https://github.com/boubkerbribri)
+
+
 ## Code changes in the '1.7.7.x' branch
 
 

--- a/news/_posts/core-weekly/2021-05-03-coreweekly-17-2021.md
+++ b/news/_posts/core-weekly/2021-05-03-coreweekly-17-2021.md
@@ -74,6 +74,30 @@ Dear developers,
 * [#23975](https://github.com/PrestaShop/PrestaShop/pull/23975): Fix ThemeExporterTest test path. Thank you [@mvorisek](https://github.com/mvorisek)
 
 
+## Code changes in the '1.7.8.x' branch
+
+
+### Back office
+* [#24272](https://github.com/PrestaShop/PrestaShop/pull/24272): Fix `dashtrends` module position during install. Thank you [@PululuK](https://github.com/PululuK)
+* [#24247](https://github.com/PrestaShop/PrestaShop/pull/24247): Add missing window assignments in javascript default theme, by [@PierreRambaud](https://github.com/PierreRambaud)
+* [#24187](https://github.com/PrestaShop/PrestaShop/pull/24187): Add hardcoded translation entry for Experimental Features Navbar link, by [@matks](https://github.com/matks)
+* [#24129](https://github.com/PrestaShop/PrestaShop/pull/24129): Fix bug on cover when you select only one image on dropzone of product page v2, by [@NeOMakinG](https://github.com/NeOMakinG)
+
+
+### Front office
+* [#24248](https://github.com/PrestaShop/PrestaShop/pull/24248): Use combination image instead of the cover image in cart, by [@PierreRambaud](https://github.com/PierreRambaud)
+
+
+### Tests
+* [#24252](https://github.com/PrestaShop/PrestaShop/pull/24252): Add more scripts on package.json, by [@boubkerbribri](https://github.com/boubkerbribri)
+* [#24246](https://github.com/PrestaShop/PrestaShop/pull/24246): Fix nightly tests for 1.7.8.x on 28-04-2021, by [@boubkerbribri](https://github.com/boubkerbribri)
+* [#24240](https://github.com/PrestaShop/PrestaShop/pull/24240): Update js documentation for Credit slips - Delivery slips - Invoices - Shopping carts pages. Thank you [@nesrineabdmouleh](https://github.com/nesrineabdmouleh)
+* [#24236](https://github.com/PrestaShop/PrestaShop/pull/24236): Update js documentation for order pages (index - add - view). Thank you [@nesrineabdmouleh](https://github.com/nesrineabdmouleh)
+* [#24215](https://github.com/PrestaShop/PrestaShop/pull/24215): Add pagination tests for monitoring page. Thank you [@nesrineabdmouleh](https://github.com/nesrineabdmouleh)
+* [#24163](https://github.com/PrestaShop/PrestaShop/pull/24163): Refacto / update FO tests pages for the js-doc. Thank you [@SD1982](https://github.com/SD1982)
+* [#24160](https://github.com/PrestaShop/PrestaShop/pull/24160): Add new test contact us from the order confirmation page. Thank you [@SD1982](https://github.com/SD1982)
+
+
 ## Code changes in the '1.7.7.x' branch
 
 

--- a/news/_posts/core-weekly/2021-05-10-coreweekly-18-2021.md
+++ b/news/_posts/core-weekly/2021-05-10-coreweekly-18-2021.md
@@ -59,6 +59,34 @@ This edition of the Core Weekly report highlights changes in PrestaShop's core c
 * [#24396](https://github.com/PrestaShop/PrestaShop/pull/24396): Fix nightly tests on develop for 07-05-2021, by [@boubkerbribri](https://github.com/boubkerbribri)
 
 
+## Code changes in the '1.7.8.x' branch
+
+
+### Back office
+* [#24286](https://github.com/PrestaShop/PrestaShop/pull/24286): Clear Module::getModuleIdByName_ when installing a module, by [@atomiix](https://github.com/atomiix)
+* [#24274](https://github.com/PrestaShop/PrestaShop/pull/24274): Fix getting CLDR data when creating a new currency, by [@atomiix](https://github.com/atomiix)
+* [#24268](https://github.com/PrestaShop/PrestaShop/pull/24268): Enable translation export button only when export choices are made, by [@atomiix](https://github.com/atomiix)
+* [#24266](https://github.com/PrestaShop/PrestaShop/pull/24266): Increase minimum size of the Quantity field in Partial Refund, by [@atomiix](https://github.com/atomiix)
+* [#24213](https://github.com/PrestaShop/PrestaShop/pull/24213): Add missing product form hooks. Thank you [@zuk3975](https://github.com/zuk3975)
+* [#24168](https://github.com/PrestaShop/PrestaShop/pull/24168): Fix obvious bugs in product page, by [@jolelievre](https://github.com/jolelievre)
+* [#24134](https://github.com/PrestaShop/PrestaShop/pull/24134): Remove combination from list, by [@jolelievre](https://github.com/jolelievre)
+* [#23865](https://github.com/PrestaShop/PrestaShop/pull/23865): Add product attribute generation to product page v2, by [@NeOMakinG](https://github.com/NeOMakinG)
+
+
+### Front office
+* [#24325](https://github.com/PrestaShop/PrestaShop/pull/24325): Move notifications inside content wrapper to fix a regression, by [@NeOMakinG](https://github.com/NeOMakinG)
+* [#24315](https://github.com/PrestaShop/PrestaShop/pull/24315): Fix quickview image size on FO, by [@NeOMakinG](https://github.com/NeOMakinG)
+* [#24270](https://github.com/PrestaShop/PrestaShop/pull/24270): Fix exception thrown in FO when category not active or doesn't exists, by [@atomiix](https://github.com/atomiix)
+
+
+### Tests
+* [#24377](https://github.com/PrestaShop/PrestaShop/pull/24377): Fix sanity workflow - Add repo to download libapache2, by [@boubkerbribri](https://github.com/boubkerbribri)
+* [#24343](https://github.com/PrestaShop/PrestaShop/pull/24343): Fix attributes and Values functional tests. Thank you [@nesrineabdmouleh](https://github.com/nesrineabdmouleh)
+* [#24288](https://github.com/PrestaShop/PrestaShop/pull/24288): Refactoring addImagesToProduct function, by [@boubkerbribri](https://github.com/boubkerbribri)
+* [#24285](https://github.com/PrestaShop/PrestaShop/pull/24285): Refacto shipping test pages for js-doc. Thank you [@SD1982](https://github.com/SD1982)
+* [#24280](https://github.com/PrestaShop/PrestaShop/pull/24280): Add Js doc for Dashboad and modules pages, by [@boubkerbribri](https://github.com/boubkerbribri)
+
+
 ## Code changes in the '1.7.7.x' branch
 
 

--- a/news/_posts/core-weekly/2021-05-17-coreweekly-19-2021.md
+++ b/news/_posts/core-weekly/2021-05-17-coreweekly-19-2021.md
@@ -41,6 +41,38 @@ This edition of the Core Weekly report highlights changes in PrestaShop's core c
 * [#22547](https://github.com/PrestaShop/PrestaShop/pull/22547): PHPStan (Level 5), by [@Progi1984](https://github.com/Progi1984)
 
 
+## Code changes in the '1.7.8.x' branch
+
+
+### Core
+* [#24506](https://github.com/PrestaShop/PrestaShop/pull/24506): Upgrade Symfony to 3.4.48, by [@matks](https://github.com/matks)
+
+
+### Back office
+* [#24479](https://github.com/PrestaShop/PrestaShop/pull/24479): Fix php7.4 incompability warning, by [@matthieu-rolland](https://github.com/matthieu-rolland)
+* [#24461](https://github.com/PrestaShop/PrestaShop/pull/24461): Fix missing _this replacement with that, by [@atomiix](https://github.com/atomiix)
+* [#24434](https://github.com/PrestaShop/PrestaShop/pull/24434): Remove order_view asset on 1.7.8.x, by [@NeOMakinG](https://github.com/NeOMakinG)
+* [#24356](https://github.com/PrestaShop/PrestaShop/pull/24356): Fix javascript error in console in multistore `create shop` page, by [@matthieu-rolland](https://github.com/matthieu-rolland)
+* [#24076](https://github.com/PrestaShop/PrestaShop/pull/24076): Adjust product v2 page design and add unavailable feature component, by [@NeOMakinG](https://github.com/NeOMakinG)
+
+
+### Front office
+* [#24457](https://github.com/PrestaShop/PrestaShop/pull/24457): Fix final summary exception, by [@atomiix](https://github.com/atomiix)
+* [#24430](https://github.com/PrestaShop/PrestaShop/pull/24430): Improve CartPresenter performance, and allow Order to retrieve default_image, by [@PierreRambaud](https://github.com/PierreRambaud)
+* [#24379](https://github.com/PrestaShop/PrestaShop/pull/24379): Fix smarty product lazy load exception, by [@atomiix](https://github.com/atomiix)
+* [#24239](https://github.com/PrestaShop/PrestaShop/pull/24239): Typo in head-jsonld.tpl, shop logo link: correction for #23151. Thank you [@fdonnet](https://github.com/fdonnet)
+
+
+### Tests
+* [#24500](https://github.com/PrestaShop/PrestaShop/pull/24500): Fix change customer message status, by [@boubkerbribri](https://github.com/boubkerbribri)
+* [#24462](https://github.com/PrestaShop/PrestaShop/pull/24462): Update js doc for customer service pages, by [@boubkerbribri](https://github.com/boubkerbribri)
+* [#24454](https://github.com/PrestaShop/PrestaShop/pull/24454): Functional tests - Fix and add tests for Features and Values. Thank you [@nesrineabdmouleh](https://github.com/nesrineabdmouleh)
+* [#24445](https://github.com/PrestaShop/PrestaShop/pull/24445): Fix click on a hidden checkbox on localization and translation page, by [@boubkerbribri](https://github.com/boubkerbribri)
+* [#24435](https://github.com/PrestaShop/PrestaShop/pull/24435): Fix click on toggle for seo and url page, by [@boubkerbribri](https://github.com/boubkerbribri)
+* [#24429](https://github.com/PrestaShop/PrestaShop/pull/24429): Do not remove modules pushed by API for UI tests, by [@matks](https://github.com/matks)
+* [#24364](https://github.com/PrestaShop/PrestaShop/pull/24364): Add 2 new test "reorder from order history list" and "reorder from order detail". Thank you [@SD1982](https://github.com/SD1982)
+
+
 ## Code changes in the '1.7.7.x' branch
 
 

--- a/news/_posts/core-weekly/2021-05-24-coreweekly-20-2021.md
+++ b/news/_posts/core-weekly/2021-05-24-coreweekly-20-2021.md
@@ -49,6 +49,35 @@ During this session we will present more of the new 1.7.8 achievements!
 * [#24592](https://github.com/PrestaShop/PrestaShop/pull/24592): Add `DbQueryCore` phpunit test . Thank you [@PululuK](https://github.com/PululuK)
 
 
+## Code changes in the '1.7.8.x' branch
+
+
+### Core
+* [#24586](https://github.com/PrestaShop/PrestaShop/pull/24586): Fix addons modules not being installed in CI, by [@atomiix](https://github.com/atomiix)
+
+
+### Back office
+* [#24527](https://github.com/PrestaShop/PrestaShop/pull/24527): Restricted to all shop context for Order Status controller, by [@Progi1984](https://github.com/Progi1984)
+* [#24456](https://github.com/PrestaShop/PrestaShop/pull/24456): Fix js error in console in multistore mode, by [@matthieu-rolland](https://github.com/matthieu-rolland)
+* [#24089](https://github.com/PrestaShop/PrestaShop/pull/24089): Improve Product getAttributesResume function for MySQL 8. Thank you [@daresh](https://github.com/daresh)
+
+
+### Front office
+* [#24428](https://github.com/PrestaShop/PrestaShop/pull/24428): Correct logo size of classic theme, by [@NeOMakinG](https://github.com/NeOMakinG)
+
+
+### Installer
+* [#24525](https://github.com/PrestaShop/PrestaShop/pull/24525): Wrong usage of shopId property during installation process, by [@PierreRambaud](https://github.com/PierreRambaud)
+
+
+### Tests
+* [#24569](https://github.com/PrestaShop/PrestaShop/pull/24569): Add js-doc to faker data classes: tag, tax, taxRule, taxRuleGroup, title, webservice, zone, by [@boubkerbribri](https://github.com/boubkerbribri)
+* [#24566](https://github.com/PrestaShop/PrestaShop/pull/24566): Add js-doc to faker data classes: Address, brand, brandAddress, carrier, attribute and value, by [@boubkerbribri](https://github.com/boubkerbribri)
+* [#24551](https://github.com/PrestaShop/PrestaShop/pull/24551): Update js documentation for shop parameters pages. Thank you [@nesrineabdmouleh](https://github.com/nesrineabdmouleh)
+* [#24478](https://github.com/PrestaShop/PrestaShop/pull/24478): Functional tests - Fix and add tests for Brands and Addresses pages. Thank you [@nesrineabdmouleh](https://github.com/nesrineabdmouleh)
+* [#24375](https://github.com/PrestaShop/PrestaShop/pull/24375): Add new test 'Guest checkout: Use different invoice address', by [@boubkerbribri](https://github.com/boubkerbribri)
+
+
 ## Code changes in the '1.7.7.x' branch
 
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer blog! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | As mentioned in https://github.com/PrestaShop/prestashop.github.io/issues/936, Core Weekly of 2021 miss 1.7.8.x PRs. This PR fixes Core Weekly 16 to 20 of 2021 with missing 178x data
| Fixed ticket? | Related to #936

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
