### PR TITLE
Fix Core Weekly 21 to 25 of 2021 with missing 178x data

### DIFF
--- a/news/_posts/core-weekly/2021-05-31-coreweekly-21-2021.md
+++ b/news/_posts/core-weekly/2021-05-31-coreweekly-21-2021.md
@@ -68,6 +68,52 @@ In the meantime, in the PHP ecosystem, Symfony released [Symfony 5.3.0](https://
 * [#24618](https://github.com/PrestaShop/PrestaShop/pull/24618): Improve `Tools` protocol check. Thank you [@PululuK](https://github.com/PululuK)
 
 
+## Code changes in the '1.7.8.x' branch
+
+
+### Core
+* [#24659](https://github.com/PrestaShop/PrestaShop/pull/24659): Improved profiler. Thank you [@kpodemski](https://github.com/kpodemski)
+* [#24611](https://github.com/PrestaShop/PrestaShop/pull/24611): Make sure array keys exist before using it for PHP7.4 compatibility, by [@PierreRambaud](https://github.com/PierreRambaud)
+* [#24242](https://github.com/PrestaShop/PrestaShop/pull/24242): Fix upgrade from 1.6.1.24 to 1.7.8.x, by [@atomiix](https://github.com/atomiix)
+
+
+### Back office
+* [#24697](https://github.com/PrestaShop/PrestaShop/pull/24697): Fix product stats alignment on order view page, by [@NeOMakinG](https://github.com/NeOMakinG)
+* [#24677](https://github.com/PrestaShop/PrestaShop/pull/24677): Update vue-style-loader to fix scoped css bug, by [@jolelievre](https://github.com/jolelievre)
+* [#24653](https://github.com/PrestaShop/PrestaShop/pull/24653): Remove abstract product handler. Thank you [@zuk3975](https://github.com/zuk3975)
+* [#24632](https://github.com/PrestaShop/PrestaShop/pull/24632): Wrong get and set data for employee options configuration, by [@PierreRambaud](https://github.com/PierreRambaud)
+* [#24614](https://github.com/PrestaShop/PrestaShop/pull/24614): Fixed error message for avoiding duplicate order message name, by [@Progi1984](https://github.com/Progi1984)
+* [#24596](https://github.com/PrestaShop/PrestaShop/pull/24596): Fix primary buttons not being inline on Theme & Logo > Pages configurations, by [@NeOMakinG](https://github.com/NeOMakinG)
+* [#24580](https://github.com/PrestaShop/PrestaShop/pull/24580): Fix  the alignment  columns  Features and Attributes. Thank you [@okom3pom](https://github.com/okom3pom)
+* [#24577](https://github.com/PrestaShop/PrestaShop/pull/24577): Customer Service page - A title section is not well displayed. Thank you [@okom3pom](https://github.com/okom3pom)
+* [#24573](https://github.com/PrestaShop/PrestaShop/pull/24573): Fix title layout on order view page, by [@NeOMakinG](https://github.com/NeOMakinG)
+* [#24572](https://github.com/PrestaShop/PrestaShop/pull/24572): Fix npm vulnerabilities and update webpack everywhere except classic, by [@NeOMakinG](https://github.com/NeOMakinG)
+* [#24541](https://github.com/PrestaShop/PrestaShop/pull/24541): Remove inline-style from form_row of the UIKit and adapt js, by [@NeOMakinG](https://github.com/NeOMakinG)
+* [#24539](https://github.com/PrestaShop/PrestaShop/pull/24539): Added style for maintenance page, by [@Progi1984](https://github.com/Progi1984)
+* [#24485](https://github.com/PrestaShop/PrestaShop/pull/24485): Fixed an error displayed in the console when changing the order status -  Orders list page . Thank you [@arouiadib](https://github.com/arouiadib)
+* [#24447](https://github.com/PrestaShop/PrestaShop/pull/24447): Fix order view layout of right column, by [@NeOMakinG](https://github.com/NeOMakinG)
+* [#24355](https://github.com/PrestaShop/PrestaShop/pull/24355): Fix Multistore dropdown in current group context, by [@matthieu-rolland](https://github.com/matthieu-rolland)
+* [#24283](https://github.com/PrestaShop/PrestaShop/pull/24283): Add info block background to order page, by [@NeOMakinG](https://github.com/NeOMakinG)
+* [#24253](https://github.com/PrestaShop/PrestaShop/pull/24253): Backport #23902 with new modal content, by [@atomiix](https://github.com/atomiix)
+* [#23900](https://github.com/PrestaShop/PrestaShop/pull/23900): Construct category tree using JS on product page v2, by [@NeOMakinG](https://github.com/NeOMakinG)
+
+
+### Front office
+* [#24610](https://github.com/PrestaShop/PrestaShop/pull/24610): Fixed check on array in template Smarty, by [@Progi1984](https://github.com/Progi1984)
+
+
+### Installer
+* [#24690](https://github.com/PrestaShop/PrestaShop/pull/24690): Update Symfony to latest patch, by [@jolelievre](https://github.com/jolelievre)
+* [#24681](https://github.com/PrestaShop/PrestaShop/pull/24681): Update prestashop modules in composer.lock, by [@jolelievre](https://github.com/jolelievre)
+
+
+### Tests
+* [#24652](https://github.com/PrestaShop/PrestaShop/pull/24652): Functional  tests - Add test merchandise return options. Thank you [@nesrineabdmouleh](https://github.com/nesrineabdmouleh)
+* [#24648](https://github.com/PrestaShop/PrestaShop/pull/24648): Fix nightly tests on 1.7.8.x for 25/05/2021. Thank you [@nesrineabdmouleh](https://github.com/nesrineabdmouleh)
+* [#24627](https://github.com/PrestaShop/PrestaShop/pull/24627): Functional tests - Add test 'Contact options'. Thank you [@nesrineabdmouleh](https://github.com/nesrineabdmouleh)
+* [#24603](https://github.com/PrestaShop/PrestaShop/pull/24603): Add js-doc to faker data classes: search, searchEngine, seoPage, shop, shopGroup, sqlQuery, state, store, supplier, by [@boubkerbribri](https://github.com/boubkerbribri)
+
+
 ## Code changes in the '1.7.7.x' branch
 
 

--- a/news/_posts/core-weekly/2021-06-07-coreweekly-22-2021.md
+++ b/news/_posts/core-weekly/2021-06-07-coreweekly-22-2021.md
@@ -46,6 +46,31 @@ This edition of the Core Weekly report highlights changes in PrestaShop's core c
 * [#24623](https://github.com/PrestaShop/PrestaShop/pull/24623): Refactor `TinyMceMaxLengthValidator`. Thank you [@PululuK](https://github.com/PululuK)
 
 
+## Code changes in the '1.7.8.x' branch
+
+
+### Back office
+* [#24745](https://github.com/PrestaShop/PrestaShop/pull/24745): Form builder modifier, by [@jolelievre](https://github.com/jolelievre)
+* [#24736](https://github.com/PrestaShop/PrestaShop/pull/24736): Fix create-test-db. Thank you [@zuk3975](https://github.com/zuk3975)
+* [#24718](https://github.com/PrestaShop/PrestaShop/pull/24718): The addProductNewInvoiceInfo is not displayed when creating new invoice, by [@PierreRambaud](https://github.com/PierreRambaud)
+* [#24696](https://github.com/PrestaShop/PrestaShop/pull/24696): Fix delete modal translation, by [@jolelievre](https://github.com/jolelievre)
+* [#24594](https://github.com/PrestaShop/PrestaShop/pull/24594): Fix order create page on product qty update, by [@NeOMakinG](https://github.com/NeOMakinG)
+* [#24330](https://github.com/PrestaShop/PrestaShop/pull/24330): Disable Menus tab and deny access, by [@sowbiba](https://github.com/sowbiba)
+
+
+### Front office
+* [#24680](https://github.com/PrestaShop/PrestaShop/pull/24680): Fix unclosed div in product-list.tpl. Thank you [@kpodemski](https://github.com/kpodemski)
+
+
+### Tests
+* [#24789](https://github.com/PrestaShop/PrestaShop/pull/24789): Add jsdoc for classes: imageType, invoice, language, orderMessage, orderReturnStatus, orderStatus, product, profile, by [@boubkerbribri](https://github.com/boubkerbribri)
+* [#24787](https://github.com/PrestaShop/PrestaShop/pull/24787): Add regression test 'Access to Menu tab on Bo should be denied', by [@boubkerbribri](https://github.com/boubkerbribri)
+* [#24775](https://github.com/PrestaShop/PrestaShop/pull/24775): Add class for columns on legacy tables to be able to target them on tests, by [@boubkerbribri](https://github.com/boubkerbribri)
+* [#24737](https://github.com/PrestaShop/PrestaShop/pull/24737): Add ids for link to download sample file on import page, by [@boubkerbribri](https://github.com/boubkerbribri)
+* [#24720](https://github.com/PrestaShop/PrestaShop/pull/24720): Add selectors for view customer service page and fix autocomplete test, by [@boubkerbribri](https://github.com/boubkerbribri)
+* [#24660](https://github.com/PrestaShop/PrestaShop/pull/24660): Update Js documentation for customers pages. Thank you [@nesrineabdmouleh](https://github.com/nesrineabdmouleh)
+
+
 ## Code changes in the '1.7.7.x' branch
 
 

--- a/news/_posts/core-weekly/2021-06-14-coreweekly-23-2021.md
+++ b/news/_posts/core-weekly/2021-06-14-coreweekly-23-2021.md
@@ -66,6 +66,51 @@ By the way, [PrestaShop 1.7.8.0 beta was released 2 weeks ago now](https://build
 * [#24730](https://github.com/PrestaShop/PrestaShop/pull/24730): Add product page link and move download in order details. Thank you [@marekjedrzejewski](https://github.com/marekjedrzejewski)
 
 
+## Code changes in the '1.7.8.x' branch
+
+
+### Core
+* [#24885](https://github.com/PrestaShop/PrestaShop/pull/24885): Register new hooks for 1.7.8.0, by [@matks](https://github.com/matks)
+* [#24829](https://github.com/PrestaShop/PrestaShop/pull/24829): Show formatted Load time in Profiler. Thank you [@kpodemski](https://github.com/kpodemski)
+* [#24821](https://github.com/PrestaShop/PrestaShop/pull/24821): Handle CustomerAddressGridDefinitionFactory in CLI context, by [@atomiix](https://github.com/atomiix)
+* [#24682](https://github.com/PrestaShop/PrestaShop/pull/24682): Add missing Grid and Router JS components. Thank you [@kpodemski](https://github.com/kpodemski)
+
+
+### Back office
+* [#24892](https://github.com/PrestaShop/PrestaShop/pull/24892): Fix experimental product page creation link, by [@matthieu-rolland](https://github.com/matthieu-rolland)
+* [#24876](https://github.com/PrestaShop/PrestaShop/pull/24876): Add classes for sort links on legacy pages, by [@boubkerbribri](https://github.com/boubkerbribri)
+* [#24867](https://github.com/PrestaShop/PrestaShop/pull/24867): Fix order notes not being saved , by [@matthieu-rolland](https://github.com/matthieu-rolland)
+* [#24848](https://github.com/PrestaShop/PrestaShop/pull/24848): Avoid setting height to 0 if height isn't defined on product dropzone, by [@NeOMakinG](https://github.com/NeOMakinG)
+* [#24837](https://github.com/PrestaShop/PrestaShop/pull/24837): Fix zoom on theme email grid and legacy dropdowns, by [@NeOMakinG](https://github.com/NeOMakinG)
+* [#24813](https://github.com/PrestaShop/PrestaShop/pull/24813): Fix header toolbar getting over content on mobile and table, by [@NeOMakinG](https://github.com/NeOMakinG)
+* [#24794](https://github.com/PrestaShop/PrestaShop/pull/24794): Fix js error when adding voucher in create order, by [@atomiix](https://github.com/atomiix)
+* [#24728](https://github.com/PrestaShop/PrestaShop/pull/24728): Remove unwanted bundle.js call, by [@PierreRambaud](https://github.com/PierreRambaud)
+* [#24665](https://github.com/PrestaShop/PrestaShop/pull/24665): Fix dropzone component design on product page v2, by [@NeOMakinG](https://github.com/NeOMakinG)
+* [#24661](https://github.com/PrestaShop/PrestaShop/pull/24661): Display tab for extra modules in product page, by [@jolelievre](https://github.com/jolelievre)
+* [#24469](https://github.com/PrestaShop/PrestaShop/pull/24469): Multistore header on product pages, by [@matthieu-rolland](https://github.com/matthieu-rolland)
+* [#24282](https://github.com/PrestaShop/PrestaShop/pull/24282): Remove unwanted margins on order page cards, by [@NeOMakinG](https://github.com/NeOMakinG)
+
+
+### Front office
+* [#24852](https://github.com/PrestaShop/PrestaShop/pull/24852): Fix 404 layout for wrong category, by [@atomiix](https://github.com/atomiix)
+* [#24849](https://github.com/PrestaShop/PrestaShop/pull/24849): Fix wrong tab selected after changing a product combination on the FO, by [@atomiix](https://github.com/atomiix)
+* [#24795](https://github.com/PrestaShop/PrestaShop/pull/24795): Fix checkout page details removed and wrong price when adding/removing voucher, by [@atomiix](https://github.com/atomiix)
+* [#24600](https://github.com/PrestaShop/PrestaShop/pull/24600): FO - Validate field values when creating customer account, by [@sowbiba](https://github.com/sowbiba)
+
+
+### Installer
+* [#24847](https://github.com/PrestaShop/PrestaShop/pull/24847): Fix hook wording. Thank you [@PululuK](https://github.com/PululuK)
+
+
+### Tests
+* [#24904](https://github.com/PrestaShop/PrestaShop/pull/24904): Wait for navigation after click on FO menu, by [@boubkerbribri](https://github.com/boubkerbribri)
+* [#24894](https://github.com/PrestaShop/PrestaShop/pull/24894): Update Js doc for design pages. Thank you [@nesrineabdmouleh](https://github.com/nesrineabdmouleh)
+* [#24879](https://github.com/PrestaShop/PrestaShop/pull/24879): Update JS documentation for international pages. Thank you [@nesrineabdmouleh](https://github.com/nesrineabdmouleh)
+* [#24870](https://github.com/PrestaShop/PrestaShop/pull/24870): Improve selectors and functions on statuses page, by [@boubkerbribri](https://github.com/boubkerbribri)
+* [#24862](https://github.com/PrestaShop/PrestaShop/pull/24862): Improve orders selectors for UI tests, by [@boubkerbribri](https://github.com/boubkerbribri)
+* [#24699](https://github.com/PrestaShop/PrestaShop/pull/24699): Functional test - Add quick access test. Thank you [@nesrineabdmouleh](https://github.com/nesrineabdmouleh)
+
+
 ## Code changes in modules, themes & tools
 
 

--- a/news/_posts/core-weekly/2021-06-21-coreweekly-24-2021.md
+++ b/news/_posts/core-weekly/2021-06-21-coreweekly-24-2021.md
@@ -72,6 +72,38 @@ In the meantime, work continues on `develop` branch for next version. Two major 
 * [#24981](https://github.com/PrestaShop/PrestaShop/pull/24981): Fix order status test after deleting status added by addons modules, by [@boubkerbribri](https://github.com/boubkerbribri)
 
 
+## Code changes in the '1.7.8.x' branch
+
+
+### Core
+* [#24866](https://github.com/PrestaShop/PrestaShop/pull/24866): Set country GB to non-EU country. Thank you [@juraj1000](https://github.com/juraj1000)
+* [#24774](https://github.com/PrestaShop/PrestaShop/pull/24774): Fix missing product indexation after creation on product page V2, by [@matthieu-rolland](https://github.com/matthieu-rolland)
+
+
+### Back office
+* [#25004](https://github.com/PrestaShop/PrestaShop/pull/25004): Fix help sidebar on Experimental Features BO Page, by [@matks](https://github.com/matks)
+* [#24918](https://github.com/PrestaShop/PrestaShop/pull/24918): Fix table responsive of multistore page, by [@NeOMakinG](https://github.com/NeOMakinG)
+* [#24899](https://github.com/PrestaShop/PrestaShop/pull/24899): Avoid errors display when Emails translations lang.php does not exist, by [@sowbiba](https://github.com/sowbiba)
+* [#24890](https://github.com/PrestaShop/PrestaShop/pull/24890): Fix top buttons on order view on mobile, by [@NeOMakinG](https://github.com/NeOMakinG)
+* [#24882](https://github.com/PrestaShop/PrestaShop/pull/24882): Restore ability to disable translations tree item, by [@sowbiba](https://github.com/sowbiba)
+* [#24851](https://github.com/PrestaShop/PrestaShop/pull/24851): Twig extension for multistore shop context URLs, by [@PierreRambaud](https://github.com/PierreRambaud)
+* [#24811](https://github.com/PrestaShop/PrestaShop/pull/24811): Fix invalid html attribute on multistore fields, by [@matthieu-rolland](https://github.com/matthieu-rolland)
+
+
+### Front office
+* [#24323](https://github.com/PrestaShop/PrestaShop/pull/24323): Update classic webpack and fix watch issue by adding webpack-cli locally, by [@NeOMakinG](https://github.com/NeOMakinG)
+* [#23480](https://github.com/PrestaShop/PrestaShop/pull/23480): Improve accessibility of classic theme forms by adding for and ids, by [@NeOMakinG](https://github.com/NeOMakinG)
+
+
+### Installer
+* [#24924](https://github.com/PrestaShop/PrestaShop/pull/24924): Add missing supplier for product pack in fixtures, by [@PierreRambaud](https://github.com/PierreRambaud)
+
+
+### Tests
+* [#24996](https://github.com/PrestaShop/PrestaShop/pull/24996): Fix nightly 17-06-2021. Thank you [@nesrineabdmouleh](https://github.com/nesrineabdmouleh)
+* [#24972](https://github.com/PrestaShop/PrestaShop/pull/24972): Functional tests - Add some refacto to orders and credit slips. Thank you [@nesrineabdmouleh](https://github.com/nesrineabdmouleh)
+
+
 ## Code changes in the '1.7.7.x' branch
 
 

--- a/news/_posts/core-weekly/2021-06-28-coreweekly-25-2021.md
+++ b/news/_posts/core-weekly/2021-06-28-coreweekly-25-2021.md
@@ -72,6 +72,35 @@ Finally, you might have noticed a change on the [Developer Documentation](https:
 * [#24188](https://github.com/PrestaShop/PrestaShop/pull/24188): Migrated some Legacy Tests to Integration/Unit Tests, by [@Progi1984](https://github.com/Progi1984)
 
 
+## Code changes in the '1.7.8.x' branch
+
+
+### Core
+* [#25131](https://github.com/PrestaShop/PrestaShop/pull/25131): Bump module ps_linklist to 5.0.2, by [@sowbiba](https://github.com/sowbiba)
+* [#25120](https://github.com/PrestaShop/PrestaShop/pull/25120): Update Welcome module to 6.0.6, by [@sowbiba](https://github.com/sowbiba)
+* [#25111](https://github.com/PrestaShop/PrestaShop/pull/25111): Fix compiled legacy container, by [@atomiix](https://github.com/atomiix)
+* [#25102](https://github.com/PrestaShop/PrestaShop/pull/25102): Update ps_linklist module to v5.0.1, by [@sowbiba](https://github.com/sowbiba)
+* [#25098](https://github.com/PrestaShop/PrestaShop/pull/25098): Remove precision type for currency, by [@sowbiba](https://github.com/sowbiba)
+
+
+### Back office
+* [#25121](https://github.com/PrestaShop/PrestaShop/pull/25121): Update translations catalogue with Welcome module wordings, by [@sowbiba](https://github.com/sowbiba)
+* [#25082](https://github.com/PrestaShop/PrestaShop/pull/25082): Fix category create in product page. Thank you [@zuk3975](https://github.com/zuk3975)
+* [#25039](https://github.com/PrestaShop/PrestaShop/pull/25039): Disable product V2 page when multistore is used, by [@matthieu-rolland](https://github.com/matthieu-rolland)
+* [#25035](https://github.com/PrestaShop/PrestaShop/pull/25035): Fix product footer direction using RTL language, by [@NeOMakinG](https://github.com/NeOMakinG)
+* [#25034](https://github.com/PrestaShop/PrestaShop/pull/25034): Fix checkbox direction on RTL, by [@NeOMakinG](https://github.com/NeOMakinG)
+* [#24869](https://github.com/PrestaShop/PrestaShop/pull/24869): Fix no active payment module displayed in Payment Methods, by [@atomiix](https://github.com/atomiix)
+* [#24052](https://github.com/PrestaShop/PrestaShop/pull/24052): Open confirm modal only when eligible for feature flag form, by [@matks](https://github.com/matks)
+* [#24025](https://github.com/PrestaShop/PrestaShop/pull/24025): Add SubmittableInput successfull and error states, by [@NeOMakinG](https://github.com/NeOMakinG)
+
+
+### Tests
+* [#25126](https://github.com/PrestaShop/PrestaShop/pull/25126): Fix currency precision regression test, by [@boubkerbribri](https://github.com/boubkerbribri)
+* [#25088](https://github.com/PrestaShop/PrestaShop/pull/25088): Functional tests - Add some refacto to Orders>Invoices tests. Thank you [@nesrineabdmouleh](https://github.com/nesrineabdmouleh)
+* [#25057](https://github.com/PrestaShop/PrestaShop/pull/25057): Fix menu check on regression test, by [@boubkerbribri](https://github.com/boubkerbribri)
+* [#25047](https://github.com/PrestaShop/PrestaShop/pull/25047): Fix nightly tests for 21-06-2021, by [@boubkerbribri](https://github.com/boubkerbribri)
+
+
 ## Code changes in the '1.7.7.x' branch
 
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer blog! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | As mentioned in https://github.com/PrestaShop/prestashop.github.io/issues/936, Core Weekly of 2021 miss 1.7.8.x PRs. This PR fixes Core Weekly 21 to 25 of 2021 with missing 178x data
| Fixed ticket? | Related to #936

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
