### PR TITLE
Fix Core Weekly 26 to 28 of 2021 with missing 178x data

### DIFF
--- a/news/_posts/core-weekly/2021-07-05-coreweekly-26-2021.md
+++ b/news/_posts/core-weekly/2021-07-05-coreweekly-26-2021.md
@@ -64,6 +64,24 @@ This edition of the Core Weekly report highlights changes in PrestaShop's core c
 * [#25127](https://github.com/PrestaShop/PrestaShop/pull/25127): Migrated some Legacy Tests to Integration/Unit Tests, by [@Progi1984](https://github.com/Progi1984)
 
 
+## Code changes in the '1.7.8.x' branch
+
+
+### Core
+* [#25141](https://github.com/PrestaShop/PrestaShop/pull/25141): Upgrade ps_linklist to 5.0.3, by [@sowbiba](https://github.com/sowbiba)
+
+
+### Front office
+* [#25101](https://github.com/PrestaShop/PrestaShop/pull/25101): Fix RTL issues on material icons on FO, by [@NeOMakinG](https://github.com/NeOMakinG)
+
+
+### Tests
+* [#25128](https://github.com/PrestaShop/PrestaShop/pull/25128): Functional tests - Add js doc for 'Advanced parameters' pages. Thank you [@nesrineabdmouleh](https://github.com/nesrineabdmouleh)
+* [#25108](https://github.com/PrestaShop/PrestaShop/pull/25108): Functional tests - Refacto 'Orders > Shopping carts' tests. Thank you [@nesrineabdmouleh](https://github.com/nesrineabdmouleh)
+* [#25104](https://github.com/PrestaShop/PrestaShop/pull/25104): Functional tests - Refacto 'Orders > Delivery slips' tests. Thank you [@nesrineabdmouleh](https://github.com/nesrineabdmouleh)
+* [#24995](https://github.com/PrestaShop/PrestaShop/pull/24995): Functional tests - Add Js doc for catalog pages. Thank you [@nesrineabdmouleh](https://github.com/nesrineabdmouleh)
+
+
 ## Code changes in modules, themes & tools
 
 

--- a/news/_posts/core-weekly/2021-07-19-coreweekly-27-2021.md
+++ b/news/_posts/core-weekly/2021-07-19-coreweekly-27-2021.md
@@ -50,6 +50,13 @@ This edition of the Core Weekly report highlights changes in PrestaShop's core c
 * [#25146](https://github.com/PrestaShop/PrestaShop/pull/25146): Separate functional tests to BO and FO and Add regression campaign to the actual run, by [@boubkerbribri](https://github.com/boubkerbribri)
 
 
+## Code changes in the '1.7.8.x' branch
+
+
+### Tests
+* [#25292](https://github.com/PrestaShop/PrestaShop/pull/25292): Fix 1.7.8.x test for product duplicate. Thank you [@okom3pom](https://github.com/okom3pom)
+
+
 ## Code changes in the '1.7.7.x' branch
 
 

--- a/news/_posts/core-weekly/2021-07-19-coreweekly-28-2021.md
+++ b/news/_posts/core-weekly/2021-07-19-coreweekly-28-2021.md
@@ -50,6 +50,14 @@ This edition of the Core Weekly report highlights changes in PrestaShop's core c
 * [#24997](https://github.com/PrestaShop/PrestaShop/pull/24997): Cancel previous build when it's possible, by [@PierreRambaud](https://github.com/PierreRambaud)
 
 
+## Code changes in the '1.7.8.x' branch
+
+
+### Tests
+* [#25344](https://github.com/PrestaShop/PrestaShop/pull/25344): Disable failing Behat test about product duplicate translation, by [@matks](https://github.com/matks)
+* [#25333](https://github.com/PrestaShop/PrestaShop/pull/25333): Caching playwright browsers on github workflows, by [@boubkerbribri](https://github.com/boubkerbribri)
+
+
 ## Code changes in the '1.7.7.x' branch
 
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer blog! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | As mentioned in https://github.com/PrestaShop/prestashop.github.io/issues/936, Core Weekly of 2021 miss 1.7.8.x PRs. This PR fixes Core Weekly 26 to 28 of 2021 with missing 178x data
| Fixed ticket? | Related to #936

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
