### PR TITLE
Use LAST_WEEK_NUM to compute CW in GH action

### DIFF
--- a/.github/workflows/coreweekly.yml
+++ b/.github/workflows/coreweekly.yml
@@ -32,7 +32,7 @@ jobs:
       run: cd ~/core-weekly-generator && pip install -r requirements.txt
  
     - name: Generate Core Weekly for the current week
-      run: cd ~/core-weekly-generator && python core-weekly.py --week ${{ env.WEEK_NUM }} > $GITHUB_WORKSPACE/news/_posts/core-weekly/$(date +"%Y-%m-%d-coreweekly-${{ env.LAST_WEEK_NUM }}-%Y.md")
+      run: cd ~/core-weekly-generator && python core-weekly.py --week ${{ env.LAST_WEEK_NUM }} > $GITHUB_WORKSPACE/news/_posts/core-weekly/$(date +"%Y-%m-%d-coreweekly-${{ env.LAST_WEEK_NUM }}-%Y.md")
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer blog! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Following bugfix https://github.com/PrestaShop/core-weekly-generator/pull/91, we should use LAST_WEEK_NUM to compute CW in GH action
| Fixed ticket? | Should fix https://github.com/PrestaShop/prestashop.github.io/issues/944

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
