### PR TITLE
Use LAST_WEEK_NUM instead of WEEK_NUM

### DIFF
--- a/.github/workflows/coreweekly.yml
+++ b/.github/workflows/coreweekly.yml
@@ -11,9 +11,6 @@ jobs:
     - name: Set variable LAST_WEEK_NUM
       run: echo "LAST_WEEK_NUM=`date -d 'last week' +"%U"`" >> $GITHUB_ENV
 
-    - name: Set variable WEEK_NUM
-      run: echo "WEEK_NUM=`date +"%U"`" >> $GITHUB_ENV
-
     - name: Set variable YEAR
       run: echo "YEAR=`date -d 'last week' +"%Y"`" >> $GITHUB_ENV
 
@@ -30,9 +27,9 @@ jobs:
 
     - name: Install dependencies
       run: cd ~/core-weekly-generator && pip install -r requirements.txt
- 
+
     - name: Generate Core Weekly for the current week
-      run: cd ~/core-weekly-generator && python core-weekly.py --week ${{ env.WEEK_NUM }} > $GITHUB_WORKSPACE/news/_posts/core-weekly/$(date +"%Y-%m-%d-coreweekly-${{ env.LAST_WEEK_NUM }}-%Y.md")
+      run: cd ~/core-weekly-generator && python core-weekly.py --week ${{ env.LAST_WEEK_NUM }} > $GITHUB_WORKSPACE/news/_posts/core-weekly/$(date +"%Y-%m-%d-coreweekly-${{ env.LAST_WEEK_NUM }}-%Y.md")
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Example, today we are in week 34, the previous week is 33. During the generation of the core weekly we are getting the work from the current week, which seems very low https://github.com/PrestaShop/prestashop.github.io/pull/953/files.  It's the same for the previous generated report: https://github.com/PrestaShop/prestashop.github.io/pull/951/files


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
