### PR TITLE
Update algolia indexes with every deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,8 +27,29 @@ jobs:
       - name: Build site
         run: hugo
 
-      - name: Create a CNAME file which mapping to our custom domain
+      - name: Create a CNAME file mapping to our custom domain
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         run: echo 'build.prestashop-project.org' > public/CNAME
+
+      - name: Set up algolia CLI
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        uses: algolia/setup-algolia-cli@master
+        with:
+          version: '1.2.1'
+        env:
+          ALGOLIA_APPLICATION_ID: ${{ secrets.BLOG_ALGOLIA_APPLICATION_ID }}
+          ALGOLIA_ADMIN_API_KEY: ${{ secrets.BLOG_ALGOLIA_ADMIN_API_KEY }}
+
+      - name: Update algolia index
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        run: |
+          algolia --version
+          echo "Clear algolia blog index"
+          algolia indices clear blog
+          echo "Push new objects"
+          algolia objects import blog -F public/algolia.ndjson 
+          echo "Clean up"
+          rm public/algolia.ndjson
 
       - name: Deploy
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ _site
 .idea
 .hugo_build.lock
 /resources
+/public/

--- a/config.yaml
+++ b/config.yaml
@@ -12,6 +12,7 @@ mainSections:
   - news
 
 cascade:
+  # default social image
   twitter_image: "/assets/images/theme/meta-logo-build.png"
 
 permalinks:
@@ -23,19 +24,36 @@ disqusShortname: prestashopbuild
 
 params:
   email: build@prestashop.com
+  # algolia search settings
   algolia:
     application_id: '17LZR6CZEL'
-    index_name: 'jekyll'
+    index_name: 'blog'
 
 social:
   twitter: "PrestaShopOrg"
   github: "PrestaShop"
 
+mediaTypes:
+  application/ndjson:
+    suffixes: ['ndjson']
+
 rssLimit: 15
+
 outputFormats:
+  # rss feed generation
   RSS:
     mediaType: application/rss+xml
     basename: feed
+  # algolia index generation
+  algolia:
+    baseName: "algolia"
+    isPlainText: true
+    mediaType: "application/ndjson"
+    notAlternative: true
+
+outputs:
+  home:
+    ["HTML", "RSS", "algolia"]
 
 markup:
   highlight:

--- a/themes/build/layouts/_default/list.algolia.ndjson
+++ b/themes/build/layouts/_default/list.algolia.ndjson
@@ -1,0 +1,19 @@
+{{- $section := $.Site.GetPage "section" .Section }}
+{{- $items := slice -}}
+{{- range where (where .Site.Pages "Type" "in" (slice "howtos" "news" "tools")) "IsPage" true -}}
+    {{- if or (and (.IsDescendant $section) (and (not .Draft) (not .Params.private))) $section.IsHome -}}
+        {{- $item := (dict
+              "objectID" .File.UniqueID
+              "content" (partial "partials/post-summary" .)
+              "title" .Title
+              "categories" (slice .Section)
+              "tags" .Params.Tags
+              "date" .Date.UTC.Unix
+              "lang" .Lang
+              "url" .RelPermalink
+            )
+        -}}
+        {{- $items = $items | append (jsonify $item) -}}
+    {{- end -}}
+{{- end -}}
+{{- delimit $items "\n" -}}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer blog! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | After switching from jekyll to hugo, we lost the updates of algolia indexes after every deployment. This change brings that back.
| Fixed ticket? | N/A

## How this works (for history!)

This works in two steps:

1. Create a [ndjson](https://github.com/ndjson/ndjson-spec) (newline-delimited json) containing all the indexes to push to algolia
2. On deployment, clear algolia's index and upload it again

The index file is created by setting up a new output format ("algolia"), that will output a single file (`algolia.ndjson`), based on the template `themes/build/layouts/_default/list.algolia.ndjson`. Once it's created, we simply use algolia's cli tool to push the file contents to our index (`blog`).

The generated `algolia.ndjson` file looks like this:

```json
{"categories":["news"],"content":"Friendly reminder, that the public demo for the PrestaShop Project will happen tomorrow, on Wednesday, December 14th, 2022 at 4pm CET!","date":1670918400,"lang":"en","objectID":"ec390c9d3c7bdceb0e80c29a4f1c5ed0","tags":["contribute","event","community"],"title":"Announcing December PrestaShop Project Public Demo","url":"/news/upcoming-demo-9-2022/"}
{"categories":["news"],"content":"It has been decided to deliver a new maintenance release for 1.7.8.x branch. Please note that this will be the last regular 1.7.8.x patch version, as the branch now enters security-only maintenance phase. Next regular patches will now target 8.0.x branch.","date":1670454000,"lang":"en","objectID":"5c8ddd6d76c5d090a98d19a84c605202","tags":["version","patch","releases","1.7.8.8","1.7.8.x"],"title":"PrestaShop 1.7.8.8 Is Available","url":"/news/prestashop-1-7-8-8-maintenance-release/"}
{"categories":["news"],"content":"Contributing to PrestaShop is not only about the code, it is also about taking part in the PrestaShop translation project! This report will tell you how the software translations evolved in November!","date":1670367600,"lang":"en","objectID":"ecb84400dd54bcb696b3a3f286764739","tags":["translation","i18n","l10n"],"title":"Do you speak PrestaShop? – November 2022 edition","url":"/news/do-you-speak-prestashop-december-2022/"}
```

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
