### PR TITLE
Use aliases as URLs for Disqus comments

### DIFF
--- a/themes/build/layouts/_default/list.html
+++ b/themes/build/layouts/_default/list.html
@@ -33,7 +33,7 @@
                   {{ .Date.Format "Jan 2, 2006" }}
                 </span>
               <span class="separator"></span>
-              <span class="disqus-comment-count" data-disqus-url="{{ default .Permalink .Params.Disqus_url }}"></span>
+              <span class="disqus-comment-count" data-disqus-url="{{ partial "partials/disqus/disqus-url.html" . }}"></span>
             </div>
 
             <h2>

--- a/themes/build/layouts/partials/disqus/disqus-url.html
+++ b/themes/build/layouts/partials/disqus/disqus-url.html
@@ -1,0 +1,7 @@
+{{ $url := .Permalink }}
+{{ if .Params.Disqus_url }}
+    {{ $url = .Params.Disqus_url }}
+{{ else if (gt (len .Aliases) 0) }}
+    {{ $url = printf "%s%s" .Site.BaseURL (index .Aliases 0) }}
+{{ end }}
+{{ return $url }}

--- a/themes/build/layouts/partials/post-disqus.html
+++ b/themes/build/layouts/partials/post-disqus.html
@@ -6,9 +6,9 @@
         {{ if .Site.DisqusShortname }}<div id="disqus_thread"></div>
         <script type="application/javascript">
           window.disqus_config = function () {
-              {{with .Params.disqus_identifier }}this.page.identifier = '{{ . }}';{{end}}
-              {{with .Params.disqus_title }}this.page.title = '{{ . }}';{{end}}
-              {{with .Params.disqus_url }}this.page.url = '{{ . | html  }}';{{end}}
+              {{ with .Params.disqus_identifier }}this.page.identifier = '{{ . }}';{{ end }}
+              {{ with .Params.disqus_title }}this.page.title = '{{ . }}';{{ end }}
+              this.page.url = '{{ partial "partials/disqus/disqus-url" . }}';
           };
           (function() {
             if (["localhost", "127.0.0.1"].indexOf(window.location.hostname) != -1) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer blog! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Disqus lost track of old comments when the URLs were changed in #1173. This change uses the first page alias as URL for Disqus comments (if an alias exists for that page).
| Fixed ticket? | Fixes #1177

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
