### PR TITLE
PrestaShop Developer Conference coming to Paris

### DIFF
--- a/content/news/posts/2023/prestashop-developer-conference-coming-to-paris.md
+++ b/content/news/posts/2023/prestashop-developer-conference-coming-to-paris.md
@@ -1,0 +1,51 @@
+---
+layout: post
+title:  The PrestaShop Developer Conference is coming to Paris!
+subtitle: "Pre-register for the event happening in Paris, France on November 30, and participate as a Speaker!"
+date:   2023-08-01
+authors: [ PrestaShop ]
+icon: icon-leaf
+tags: [ news, event, community ]
+---
+
+Are you a passionate PrestaShop developer or enthusiast, wanting to expand your knowledge and network within the community? The PrestaShop team is happy to let you know the call for presentations is open for the PrestaShop Developer Conference, taking place in Paris, France on November 30, 2023. This event promises to be an opportunity to engage in technical discussions, discover solutions, and connect with like-minded peers in the community.
+
+### So, what is the PrestaShop Developer Conference?
+
+The PrestaShop Developer Conference is an event designed to empower the developer community in the PrestaShop ecosystem. Whether you're a seasoned expert or just starting with PrestaShop, this conference will offer the opportunity to share your expertise, get insights, network, and learn more about PrestaShop. It’s also a place to know more about contributing to the open source community.
+
+Here are some of the benefits of participating:
+
+1. Technical talks and solution demonstrations: gain insights about PrestaShop technology with engaging technical talks, and follow solution demonstrations that will help you broaden your understanding and enhance your skills.
+
+2. Share your expertise: as part of the conference program, you are invited to submit your own talks and share your knowledge with the community. This is your chance to come on stage and present your innovations and experiences.
+
+3. Expand your network: meet like-minded PrestaShop developers, community members and enthusiasts. Make meaningful connections that may lead to collaborations and new opportunities.
+
+4. Strengthen the community: your participation not only benefits you individually but also contributes to the growth and advancement of the community. By sharing your knowledge, you play an important role in fostering a culture of collaboration.
+
+### We are looking for speakers!
+
+For this year's conference, presentations on a variety of themes are welcomed. All topics about PrestaShop development are valid, but we are especially interested in the following subjects:
+
+1. Module & theme development: share best practices and insights into developing effective modules and themes for PrestaShop.
+
+2. Performance optimization: strategies for optimizing PrestaShop performance, improving loading times, and enhancing user experience.
+
+3. Solutions for developers: showcase innovative solutions and tools that can streamline the development process.
+
+4. New PrestaShop features: explain how to leverage recent additions to PrestaShop to develop engaging solutions.
+
+5. Security best practices: educate other developers about ensuring the security of stores.
+
+6. Deployment - CI/CD (Continuous Integration/Continuous Deployment): share best practices and methodologies for seamless deployment in a CI/CD environment.
+
+To submit your presentation, [visit the event website and the dedicated form](https://events.prestashop.com/prestashop-developer-conference/en#bl-cf599202-a7aa-4246-9706-c5fb0a3a124e) to confirm your interest. You will be able to select themes, talk duration and confirm your session description so event organizers can prepare for the Developer Conference. The deadline to submit your presentation is set to September 29, 2023.
+
+### Pre-register now
+
+Excited to be a part of this gathering? Secure your spot! To pre-register for the PrestaShop Developer Conference 2023, simply [fill in your email address on the conference’s website](https://events.prestashop.com/prestashop-developer-conference/en#bl-07d0ab14-17c4-4c69-fd6c-927c04879bc7). By signing up early, you'll gain priority access to registration information.
+
+The PrestaShop Developer Conference 2023 will offer you the chance to engage, learn, and grow within the PrestaShop community. By participating in this event, you'll not only elevate your own skills but also contribute to the community as a whole. Mark your calendars for November 30, 2023, and get ready for a day of knowledge-sharing, networking, and inspiration in Paris.
+
+**To pre-register and answer the call for paper, [please visit the event’s website by clicking this link](https://events.prestashop.com/prestashop-developer-conference/en).**


### PR DESCRIPTION
This blog post is about the PrestaShop Developer Conference coming to Paris in November 2023.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer blog! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This pull request is for a blog post creation, about the PrestaShop Developer Conference coming to Paris in November 2023.
| Fixed ticket? | Fixes #{issue number here} if there is a related issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
