### PR TITLE
Add article to announce that PrestaShop 8.2.x is now in the extended support phase

### DIFF
--- a/content/news/posts/2025/82x-extended-support-phase.md
+++ b/content/news/posts/2025/82x-extended-support-phase.md
@@ -46,7 +46,7 @@ Patches for branch `9.0.x` will be delivered until PrestaShop 9.1.0 is released.
 
 ### develop
 
-The `develop` branch is always the next minor or major release. As of today, code changes merged inside this branch will be shipped with the next minor PrestaShop 9 version: PrestaShop 9.1.0. When PrestaShop 9.1.0 feature freeze happens, a `9.1.x` branch will be created from `develop`, and `develop` will become the recipient for changes for the version after PrestaShop 9.1.0, version 10.0.0.
+The `develop` branch is always the next minor or major release. As of today, code changes merged inside this branch will be shipped with the next minor PrestaShop 9 version: PrestaShop 9.1.0. When PrestaShop 9.1.0 feature freeze happens, a `9.1.x` branch will be created from `develop`, and `develop` will become the recipient for changes for the version after PrestaShop 9.1.0: version 10.0.0.
 
 You can read more about a minor version lifecycle [here](https://build.prestashop-project.org/news/2020/ps17-minor-release-lifecycle/).
 

--- a/content/news/posts/2025/82x-extended-support-phase.md
+++ b/content/news/posts/2025/82x-extended-support-phase.md
@@ -28,7 +28,7 @@ On the [PrestaShop main repository](https://github.com/prestashop/prestashop), t
 
 ### 8.2.x
 
-Branch `8.2.x` is the branch that gave birth to PrestaShop 8.2.0 and the patches that followed. As of today, last 8.2 version is [PrestaShop patch release 8.2.1](https://github.com/PrestaShop/PrestaShop/tree/8.2.1).
+Branch `8.2.x` is the branch that gave birth to PrestaShop 8.2.0 and the patches that followed. As of today, the last 8.2 version is [PrestaShop patch release 8.2.1](https://github.com/PrestaShop/PrestaShop/tree/8.2.1).
 
 Following PrestaShop 9.0.0 release, the `8.2.x` branch has entered the security-only maintenance phase. It means that patch releases of PrestaShop 8.2.2 and newer will only be published if critical bugs are reported, if security fixes are needed or to introduce new hooks if needed.
 

--- a/content/news/posts/2025/82x-extended-support-phase.md
+++ b/content/news/posts/2025/82x-extended-support-phase.md
@@ -46,7 +46,7 @@ Patches for branch `9.0.x` will be delivered until PrestaShop 9.1.0 is released.
 
 ### develop
 
-The `develop` branch is always the next minor or major release. As of today, code changes merged inside this branch will be shipped with the next PrestaShop 9 version: PrestaShop 9.1.0. When PrestaShop 9.1.0 feature freeze happens, a `9.1.x` branch will be created from `develop`, and `develop` will become the recipient for changes for the version after PrestaShop 9.1.0, version 10.0.0.
+The `develop` branch is always the next minor or major release. As of today, code changes merged inside this branch will be shipped with the next minor PrestaShop 9 version: PrestaShop 9.1.0. When PrestaShop 9.1.0 feature freeze happens, a `9.1.x` branch will be created from `develop`, and `develop` will become the recipient for changes for the version after PrestaShop 9.1.0, version 10.0.0.
 
 You can read more about a minor version lifecycle [here](https://build.prestashop-project.org/news/2020/ps17-minor-release-lifecycle/).
 

--- a/content/news/posts/2025/82x-extended-support-phase.md
+++ b/content/news/posts/2025/82x-extended-support-phase.md
@@ -24,7 +24,7 @@ The model was refined over the years, for example with [this developer documenta
 
 As of today, June 2025, what are the maintained branches and how do they comply with this model?
 
-On [PrestaShop main repository](https://github.com/prestashop/prestashop), three branches are maintained.
+On the [PrestaShop main repository](https://github.com/prestashop/prestashop), three branches are maintained.
 
 ### 8.2.x
 

--- a/content/news/posts/2025/82x-extended-support-phase.md
+++ b/content/news/posts/2025/82x-extended-support-phase.md
@@ -1,0 +1,62 @@
+---
+layout: post
+title: "PrestaShop 8.2.x is now in the extended support phase"
+subtitle: "What to expect for PrestaShop 8.2 and 9"
+date: 2025-07-01
+authors: [CyrilNavarro]
+icon: icon-code
+tags:
+  - version
+  - releases
+  - 8.2.x
+  - 9.0.x
+---
+
+Now that PrestaShop 9.0 is out, here is a focus on maintained branches of the PrestaShop project and what to expect.
+
+## **Reminder: PrestaShop branching strategy**
+
+In [August 2015](https://build.prestashop-project.org/news/2015/introducing-new-branching-model-prestashop/) PrestaShop adopted a new branching model for the project.
+
+The model was refined over the years, for example with [this page on the developer documentation](https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/supported-branches/#bug-fixes-and-patch-branches) about what bugs do qualify for a patch version or the [Backward Compatibility Promise](https://github.com/PrestaShop/ADR/blob/master/0017-backward-compatibility-promise.md) that defines what changes can be introduced in a version, but we can say the model has lived quite well as the project is still following it in 2025.
+
+## **PrestaShop branches in 2025**
+
+As of today, June 2025, what are the maintained branches and how do they comply with this model?
+
+On [PrestaShop main repository](https://github.com/prestashop/prestashop), three branches are maintained.
+
+### **8.2.x**
+
+Branch `8.2.x` is the branch that gave birth to PrestaShop 8.2.0 and the patches that followed. As of today, last 8.2 version is [PrestaShop patch release 8.2.1](https://github.com/PrestaShop/PrestaShop/tree/8.2.1).
+
+Following PrestaShop 9.0.0 release, the `8.2.x` branch has entered the security-only maintenance phase. It means that patch releases of PrestaShop 8.2.2 and newer will only be published to address security issues or to introduce new hooks if needed.
+
+> **Warning:** In case of incident or significant issue, a new version on the `8.2.x` branch may still be released.
+
+Consequently, please do not open a pull request against this branch unless it is a bug fix that solves a critical or security bug. Other pull requests will not be accepted.
+
+This maintenance period will end when PrestaShop 10.0.0 is released. When this day comes, PrestaShop 8.2 will not be maintained anymore.
+
+### **9.0.x**
+
+Branch `9.0.x` is the branch that introduced PrestaShop 9.0.0 and the patches that will follow. It was taken out from the `develop` branch when [PrestaShop 9.0 beta](https://build.prestashop-project.org/news/2025/prestashop-9-0-beta-release/) happened in February 2025.
+
+Following PrestaShop 9.0.0 release, the `9.0.x` branch is now the supported patch branch. It receives critical bug fixes, security bug fixes, and same-version regression fixes. You can read more about a patch version lifecycle [here](https://build.prestashop-project.org/news/2020/ps17-patch-release-lifecycle/).
+
+Patches for branch `9.0.x` will be delivered until PrestaShop 9.1.0 is released.
+
+### **develop**
+
+The `develop` branch is always the next minor or major release. As of today, code changes merged inside this branch will be shipped with the next PrestaShop 9 version: PrestaShop 9.1.0. When PrestaShop 9.1.0 feature freeze happens, a `9.1.x` branch will be created from `develop`, and `develop` will become the recipient for changes for the version after PrestaShop 9.1.0, version 10.0.0.
+
+You can read more about a minor version lifecycle [here](https://build.prestashop-project.org/news/2020/ps17-minor-release-lifecycle/).
+
+Most changes to the PrestaShop project should be submitted against this branch.
+
+## **Next versions to be released**
+
+As explained above, the two next versions of PrestaShop that can be expected are:
+
+- Patch version **9.0.1**, release of the `9.0.x` branch
+- Minor version **9.1.0**, release of the `9.1.x` branch (not created yet)

--- a/content/news/posts/2025/82x-extended-support-phase.md
+++ b/content/news/posts/2025/82x-extended-support-phase.md
@@ -30,9 +30,7 @@ On [PrestaShop main repository](https://github.com/prestashop/prestashop), three
 
 Branch `8.2.x` is the branch that gave birth to PrestaShop 8.2.0 and the patches that followed. As of today, last 8.2 version is [PrestaShop patch release 8.2.1](https://github.com/PrestaShop/PrestaShop/tree/8.2.1).
 
-Following PrestaShop 9.0.0 release, the `8.2.x` branch has entered the security-only maintenance phase. It means that patch releases of PrestaShop 8.2.2 and newer will only be published to address security issues or to introduce new hooks if needed.
-
-> **Warning:** In case of incident or significant issue, a new version on the `8.2.x` branch may still be released.
+Following PrestaShop 9.0.0 release, the `8.2.x` branch has entered the security-only maintenance phase. It means that patch releases of PrestaShop 8.2.2 and newer will only be published if critical bugs are reported, if security fixes are needed or to introduce new hooks if needed.
 
 Consequently, please do not open a pull request against this branch unless it is a bug fix that solves a critical or security bug. Other pull requests will not be accepted.
 

--- a/content/news/posts/2025/82x-extended-support-phase.md
+++ b/content/news/posts/2025/82x-extended-support-phase.md
@@ -30,7 +30,7 @@ On the [PrestaShop main repository](https://github.com/prestashop/prestashop), t
 
 Branch `8.2.x` is the branch that gave birth to PrestaShop 8.2.0 and the patches that followed. As of today, the last 8.2 version is [PrestaShop patch release 8.2.1](https://github.com/PrestaShop/PrestaShop/tree/8.2.1).
 
-Following the PrestaShop 9.0.0 release, the `8.2.x` branch has entered the security-only maintenance phase. It means that patch releases of PrestaShop 8.2.2 and newer will only be published if critical bugs are reported, if security fixes are needed or to introduce new hooks if necessary.
+Following the PrestaShop 9.0.0 release, the `8.2.x` branch has entered in the extended support phase. It means that patch releases of PrestaShop 8.2.2 and newer will only be published if critical bugs are reported, if security fixes are needed or to introduce new hooks if necessary.
 
 Consequently, please avoid opening pull requests against this branch unless they address critical or security-related bugs. While we aim to follow this policy strictly, we reserve the right to make exceptions or revise it if circumstances change.
 

--- a/content/news/posts/2025/82x-extended-support-phase.md
+++ b/content/news/posts/2025/82x-extended-support-phase.md
@@ -2,7 +2,7 @@
 layout: post
 title: "PrestaShop 8.2.x is now in the extended support phase"
 subtitle: "What to expect for PrestaShop 8.2 and 9"
-date: 2025-07-01
+date: 2025-07-04
 authors: [CyrilNavarro]
 icon: icon-code
 tags:

--- a/content/news/posts/2025/82x-extended-support-phase.md
+++ b/content/news/posts/2025/82x-extended-support-phase.md
@@ -32,7 +32,7 @@ Branch `8.2.x` is the branch that gave birth to PrestaShop 8.2.0 and the patches
 
 Following PrestaShop 9.0.0 release, the `8.2.x` branch has entered the security-only maintenance phase. It means that patch releases of PrestaShop 8.2.2 and newer will only be published if critical bugs are reported, if security fixes are needed or to introduce new hooks if needed.
 
-Consequently, please do not open a pull request against this branch unless it is a bug fix that solves a critical or security bug. Other pull requests will not be accepted.
+Consequently, please avoid opening pull requests against this branch unless they address critical or security-related bugs. While we aim to follow this policy strictly, we reserve the right to make exceptions or revise it if circumstances change.
 
 This maintenance period will end when PrestaShop 10.0.0 is released. When this day comes, PrestaShop 8.2 will not be maintained anymore.
 

--- a/content/news/posts/2025/82x-extended-support-phase.md
+++ b/content/news/posts/2025/82x-extended-support-phase.md
@@ -40,7 +40,7 @@ This maintenance period will end when PrestaShop 10.0.0 is released. When this d
 
 Branch `9.0.x` is the branch that introduced PrestaShop 9.0.0 and the patches that will follow. It was taken out from the `develop` branch when [PrestaShop 9.0 beta](https://build.prestashop-project.org/news/2025/prestashop-9-0-beta-release/) happened in February 2025.
 
-Following PrestaShop 9.0.0 release, the `9.0.x` branch is now the supported patch branch. It receives critical bug fixes, security bug fixes, and same-version regression fixes. You can read more about a patch version lifecycle [here](https://build.prestashop-project.org/news/2020/ps17-patch-release-lifecycle/).
+Following PrestaShop 9.0.0 release, the `9.0.x` branch is now the supported patch branch. It receives critical bug fixes, security bug fixes, and fixes for same-version regressions, as well as community-contributed fixes. You can read more about a patch version lifecycle [here](https://build.prestashop-project.org/news/2020/ps17-patch-release-lifecycle/).
 
 Patches for branch `9.0.x` will be delivered until PrestaShop 9.1.0 is released.
 

--- a/content/news/posts/2025/82x-extended-support-phase.md
+++ b/content/news/posts/2025/82x-extended-support-phase.md
@@ -18,7 +18,7 @@ Now that PrestaShop 9.0 is out, here is a focus on maintained branches of the Pr
 
 In [August 2015](https://build.prestashop-project.org/news/2015/introducing-new-branching-model-prestashop/) PrestaShop adopted a new branching model for the project.
 
-The model was refined over the years, for example with [this page on the developer documentation](https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/supported-branches/#bug-fixes-and-patch-branches) about what bugs do qualify for a patch version or the [Backward Compatibility Promise](https://github.com/PrestaShop/ADR/blob/master/0017-backward-compatibility-promise.md) that defines what changes can be introduced in a version, but we can say the model has lived quite well as the project is still following it in 2025.
+The model was refined over the years, for example with [this developer documentation page](https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/supported-branches/#bug-fixes-and-patch-branches) about which bugs qualify for a patch version or the [Backward Compatibility Promise](https://github.com/PrestaShop/ADR/blob/master/0017-backward-compatibility-promise.md) that defines which changes can be introduced in a version. We can say the model has lived quite well as the project is still following it in 2025.
 
 ## PrestaShop branches in 2025
 

--- a/content/news/posts/2025/82x-extended-support-phase.md
+++ b/content/news/posts/2025/82x-extended-support-phase.md
@@ -30,7 +30,7 @@ On the [PrestaShop main repository](https://github.com/prestashop/prestashop), t
 
 Branch `8.2.x` is the branch that gave birth to PrestaShop 8.2.0 and the patches that followed. As of today, the last 8.2 version is [PrestaShop patch release 8.2.1](https://github.com/PrestaShop/PrestaShop/tree/8.2.1).
 
-Following PrestaShop 9.0.0 release, the `8.2.x` branch has entered the security-only maintenance phase. It means that patch releases of PrestaShop 8.2.2 and newer will only be published if critical bugs are reported, if security fixes are needed or to introduce new hooks if needed.
+Following the PrestaShop 9.0.0 release, the `8.2.x` branch has entered the security-only maintenance phase. It means that patch releases of PrestaShop 8.2.2 and newer will only be published if critical bugs are reported, if security fixes are needed or to introduce new hooks if necessary.
 
 Consequently, please avoid opening pull requests against this branch unless they address critical or security-related bugs. While we aim to follow this policy strictly, we reserve the right to make exceptions or revise it if circumstances change.
 

--- a/content/news/posts/2025/82x-extended-support-phase.md
+++ b/content/news/posts/2025/82x-extended-support-phase.md
@@ -14,19 +14,19 @@ tags:
 
 Now that PrestaShop 9.0 is out, here is a focus on maintained branches of the PrestaShop project and what to expect.
 
-## **Reminder: PrestaShop branching strategy**
+## Reminder: PrestaShop branching strategy
 
 In [August 2015](https://build.prestashop-project.org/news/2015/introducing-new-branching-model-prestashop/) PrestaShop adopted a new branching model for the project.
 
 The model was refined over the years, for example with [this page on the developer documentation](https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/supported-branches/#bug-fixes-and-patch-branches) about what bugs do qualify for a patch version or the [Backward Compatibility Promise](https://github.com/PrestaShop/ADR/blob/master/0017-backward-compatibility-promise.md) that defines what changes can be introduced in a version, but we can say the model has lived quite well as the project is still following it in 2025.
 
-## **PrestaShop branches in 2025**
+## PrestaShop branches in 2025
 
 As of today, June 2025, what are the maintained branches and how do they comply with this model?
 
 On [PrestaShop main repository](https://github.com/prestashop/prestashop), three branches are maintained.
 
-### **8.2.x**
+### 8.2.x
 
 Branch `8.2.x` is the branch that gave birth to PrestaShop 8.2.0 and the patches that followed. As of today, last 8.2 version is [PrestaShop patch release 8.2.1](https://github.com/PrestaShop/PrestaShop/tree/8.2.1).
 
@@ -38,7 +38,7 @@ Consequently, please do not open a pull request against this branch unless it is
 
 This maintenance period will end when PrestaShop 10.0.0 is released. When this day comes, PrestaShop 8.2 will not be maintained anymore.
 
-### **9.0.x**
+### 9.0.x
 
 Branch `9.0.x` is the branch that introduced PrestaShop 9.0.0 and the patches that will follow. It was taken out from the `develop` branch when [PrestaShop 9.0 beta](https://build.prestashop-project.org/news/2025/prestashop-9-0-beta-release/) happened in February 2025.
 
@@ -46,7 +46,7 @@ Following PrestaShop 9.0.0 release, the `9.0.x` branch is now the supported patc
 
 Patches for branch `9.0.x` will be delivered until PrestaShop 9.1.0 is released.
 
-### **develop**
+### develop
 
 The `develop` branch is always the next minor or major release. As of today, code changes merged inside this branch will be shipped with the next PrestaShop 9 version: PrestaShop 9.1.0. When PrestaShop 9.1.0 feature freeze happens, a `9.1.x` branch will be created from `develop`, and `develop` will become the recipient for changes for the version after PrestaShop 9.1.0, version 10.0.0.
 
@@ -54,9 +54,9 @@ You can read more about a minor version lifecycle [here](https://build.prestasho
 
 Most changes to the PrestaShop project should be submitted against this branch.
 
-## **Next versions to be released**
+## Next versions to be released
 
 As explained above, the two next versions of PrestaShop that can be expected are:
 
-- Patch version **9.0.1**, release of the `9.0.x` branch
+- [Patch version 9.0.1](https://github.com/PrestaShop/PrestaShop/issues/38880), release of the `9.0.x` branch
 - Minor version **9.1.0**, release of the `9.1.x` branch (not created yet)

--- a/data/authors.yml
+++ b/data/authors.yml
@@ -531,3 +531,10 @@ VincentGuesnard:
     avatar: https://avatars.githubusercontent.com/u/315173?v=4
     github: touchweb-vincent
     website: https://www.touchweb.fr/
+
+CyrilNavarro:
+    display_name: Cyril Navarro
+    role: Senior Engineering Manager
+    avatar: https://avatars.githubusercontent.com/u/127135637?v=4
+    email: cyril.navarro@prestashop.com
+    github: cnavarro-prestashop


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Add article to announce that PrestaShop 8.2.x is now in the extended support phase
| Fixed ticket? | N/A

